### PR TITLE
임시 모바일 대응

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, minimum-scale=0.2, maximum-scale=1.0"/>
   <meta name="theme-color" content="#000000" />
   <meta name="description" content="Web site created using create-react-app" />
   <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@300;400;700&display=swap" rel="stylesheet">

--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -6,6 +6,7 @@ import Title from "../utils/Title";
 import "../../css/BookDetail.css";
 import BackGround from "../utils/BackGround";
 import BookStatus from "./BookStatus";
+import IMGERR from "../../img/image_onerror.svg";
 // eslint-disable-next-line react/prop-types
 
 const BookDetail = ({ location, match }) => {
@@ -22,6 +23,10 @@ const BookDetail = ({ location, match }) => {
   };
 
   useEffect(fetchData, []);
+
+  function subtituteImg(e) {
+    e.target.src = IMGERR;
+  }
 
   return (
     <main className="bookdetail-main">
@@ -43,7 +48,7 @@ const BookDetail = ({ location, match }) => {
         </div>
         <div className="bookcontent">
           <div className="bookDetail__photo">
-            <img src={data.image} alt={data.title} />
+            <img src={data.image} alt={data.title} onError={subtituteImg} />
           </div>
           <div className="bookDetail__info">
             <span className="bookinfo__title color-red">도서정보</span>

--- a/src/component/information/Question.js
+++ b/src/component/information/Question.js
@@ -20,7 +20,7 @@ const QnA = ({ isOpen, question, answer, link }) => {
         <span className="question__text font-28-bold color-54">{question}</span>
       </button>
       {onOff ? (
-        <span className="qna__answer font-16 color-a4">
+        <span className="qna__answer font-16 color-54">
           <a href="/" className={`${!link && "display-none"}`}>
             클릭
           </a>

--- a/src/component/main/MainNewBook.js
+++ b/src/component/main/MainNewBook.js
@@ -1,8 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import IMGERR from "../../img/image_onerror.svg";
 
 const MainNewBook = ({ book }) => {
+  function subtituteImg(e) {
+    e.target.src = IMGERR;
+  }
   return (
     <div className="main-new__book">
       <Link
@@ -13,7 +17,12 @@ const MainNewBook = ({ book }) => {
           },
         }}
       >
-        <img className="main-new__book-img" src={book.image} alt="new" />
+        <img
+          className="main-new__book-img"
+          src={book.image}
+          alt="new"
+          onError={subtituteImg}
+        />
       </Link>
     </div>
   );

--- a/src/component/main/MainPopularBook.js
+++ b/src/component/main/MainPopularBook.js
@@ -1,22 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
 import "../../css/MainPopularBook.css";
+import IMGERR from "../../img/image_onerror.svg";
 
 const MainPopularBook = ({ book, setMain }) => {
   function onMain() {
     setMain(book);
   }
+  function subtituteImg(e) {
+    e.target.src = IMGERR;
+  }
   return (
     <button
       className="main-popular__booklist__book-button"
       type="button"
-      value="wow"
       onClick={onMain}
     >
       <img
         className="main-popular__booklist__book-cover"
         src={book.image}
         alt={book.title}
+        onError={subtituteImg}
       />
       <p className="font-16-bold color-2d main-popular__booklist__title">
         {book.title}

--- a/src/component/main/MainPopularMain.js
+++ b/src/component/main/MainPopularMain.js
@@ -1,8 +1,12 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import IMGERR from "../../img/image_onerror.svg";
 
 const MainPopularMain = ({ main }) => {
+  function subtituteImg(e) {
+    e.target.src = IMGERR;
+  }
   return (
     <>
       <div className="main-popular__description color-54">
@@ -40,6 +44,7 @@ const MainPopularMain = ({ main }) => {
             src={main.image}
             alt={main.title}
             className="main-popular__cover-img"
+            onError={subtituteImg}
           />
           <div className="main-popular__cover-more font-20 color-ff">
             도서 자세히 보기

--- a/src/component/reservation/Reservation.js
+++ b/src/component/reservation/Reservation.js
@@ -19,7 +19,7 @@ const Reservation = ({ bookId, closeModal, setClosable }) => {
         setPropsNumber(response.data.count);
         setReservationStep("success");
         if (response.data.count === 1) {
-          const date = response.data.lendarableDate;
+          const date = response.data.lenderableDate;
           setPropsString(date.slice(2, 10).replaceAll("-", "."));
         }
       })
@@ -37,7 +37,7 @@ const Reservation = ({ bookId, closeModal, setClosable }) => {
 
   const tryReservation = async () => {
     setClosable(false);
-    setReservationStep(1);
+    setReservationStep("");
     postReservation();
     setClosable(true);
   };
@@ -50,6 +50,8 @@ const Reservation = ({ bookId, closeModal, setClosable }) => {
             bookId={bookId}
             closeModal={closeModal}
             onConfirm={tryReservation}
+            setReservationStep={setReservationStep}
+            setErrorMessage={setPropsString}
           />
         );
       case "success":

--- a/src/component/reservation/SuccessRsv.js
+++ b/src/component/reservation/SuccessRsv.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 
 const successMessage = lendabledate => {
   if (lendabledate)
-    return `대출 가능 일자는 ${lendabledate}.입니다. 감사합니다.`;
+    return `대출 가능 예상일자는 ${lendabledate}.입니다. \n대출이 가능해지면 Slack 알림을 보내드리겠습니다.`;
   return "대출이 가능해지면 Slack 알림을 보내드리겠습니다.";
 };
 

--- a/src/component/reservation/UserConfirm.js
+++ b/src/component/reservation/UserConfirm.js
@@ -2,13 +2,27 @@ import React, { useEffect, useState } from "react";
 import axios from "axios";
 import PropTypes from "prop-types";
 
-const UserConfirm = ({ bookId, closeModal, onConfirm }) => {
+const UserConfirm = ({
+  bookId,
+  closeModal,
+  onConfirm,
+  setReservationStep,
+  setErrorMessage,
+}) => {
   const [expectedRank, setExpectedRank] = useState(-1);
   useEffect(() => {
     axios
       .get(`${process.env.REACT_APP_API}/books/${bookId}/reservations/count/`)
       .then(response => {
         setExpectedRank(response.data.count);
+      })
+      .catch(error => {
+        setReservationStep("failure");
+        setErrorMessage(
+          error.response.data.message
+            ? error.response.data.message
+            : error.message,
+        );
       });
   }, []);
   const onCancel = () => {
@@ -54,4 +68,6 @@ UserConfirm.propTypes = {
   bookId: PropTypes.number.isRequired,
   closeModal: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
+  setReservationStep: PropTypes.func.isRequired,
+  setErrorMessage: PropTypes.func.isRequired,
 };

--- a/src/component/search/BookInfo.js
+++ b/src/component/search/BookInfo.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { Link } from "react-router-dom";
 import LinkToDetail from "../../img/link_to_detail.svg";
 import "../../css/BookInfo.css";
+import IMGERR from "../../img/image_onerror.svg";
 
 const BookInfo = ({
   id,
@@ -21,6 +22,10 @@ const BookInfo = ({
   };
 
   const { year, month } = parseDate(publishedAt);
+
+  function subtituteImg(e) {
+    e.target.src = IMGERR;
+  }
 
   return (
     <div className="book-info-wraper">
@@ -44,6 +49,7 @@ const BookInfo = ({
           src={image}
           alt={title}
           title={title}
+          onError={subtituteImg}
         />
         {/* <div className="book-info__available color-ff font-14">대여가능</div> */}
         <div className="book-info__info">

--- a/src/css/BackGround.css
+++ b/src/css/BackGround.css
@@ -2,7 +2,7 @@
   background-repeat: no-repeat;
   background-size: cover;
   background-position: center;
-  min-width: 1440px;
+  min-width: 1200px;
   width: 100%;
   position: absolute;
   z-index: 1;

--- a/src/css/BookDetail.css
+++ b/src/css/BookDetail.css
@@ -1,11 +1,11 @@
 .bookdetail-main {
-  min-width: 1440px;
+  min-width: 1200px;
   margin: 0px auto;
   margin-bottom: 300px;
 }
 .bookdetail-title {
   position: relative;
-  padding: 89px 270px 60px 270px;
+  padding: 89px 0 60px ;
   min-width: 900px;
   height: 107px;
   z-index: 2;

--- a/src/css/Footer.css
+++ b/src/css/Footer.css
@@ -3,7 +3,7 @@
   align-items: center;
   justify-content: center;
   background-color: #2d2d2d;
-  min-width: 1440px;
+  min-width: 1200px;
   position: relative;
   z-index: 2;
 }

--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -7,7 +7,7 @@ a:active {
 }
 
 .header {
-  padding: 80px 270px 0 270px;
+  padding: 80px 150px 0 150px;
   display: flex;
   height: 164px;
   max-width: 1200px;

--- a/src/css/Information.css
+++ b/src/css/Information.css
@@ -14,14 +14,14 @@
 
 .information-wraper {
   position: relative;
-  padding: 0 270px 60px 0;
+  padding: 0 150px 60px 0;
   min-width: 900px;
   z-index: 2;
 }
 
 .information-title {
   position: relative;
-  padding: 89px 270px 60px 270px;
+  padding: 89px 150px 60px 150px;
   min-width: 900px;
   height: 107px;
   z-index: 2;
@@ -30,7 +30,7 @@
 .information-section {
   min-width: 900px;
   max-width: 1200px;
-  padding: 0 270px 0 270px;
+  padding: 0 150px 0 150px;
   margin: auto;
 }
 

--- a/src/css/MainHome.css
+++ b/src/css/MainHome.css
@@ -1,6 +1,6 @@
 
 .main-home {
-  padding: 0 270px 0 270px;
+  padding: 0 150px 0 150px;
   position: relative;
   z-index: 2;
 }
@@ -52,4 +52,10 @@
 
 .main-home__scroll_icon {
   margin-top: 16px;
+}
+
+@media screen and (max-width:1200px){
+  .main-home__scroll {
+    display: none;
+  }
 }

--- a/src/css/MainNew.css
+++ b/src/css/MainNew.css
@@ -53,7 +53,6 @@
   display: inline-block;
   margin-left: 20px;
   vertical-align: top;
-  background-color: #a4a4a4;
 }
 
 .main-new__book:hover {

--- a/src/css/MainPopular.css
+++ b/src/css/MainPopular.css
@@ -1,11 +1,11 @@
 .main-popular {
   margin-top: 240px;
-  padding: 0 120px 0 120px;
+  padding: 0;
   margin-bottom: 300px;
 }
 
 .main-popular__wrapper {
-  width: 1200px;
+  width: 1140px;
   height: 803px;
   margin: 0px auto;
 }
@@ -42,7 +42,7 @@
 
 
 .main-popular__description {
-  margin-left: 390px;
+  margin-left: 370px;
   border-bottom: 1px solid rgba(45, 45, 45, 0.4);
   height: 159px;
 }
@@ -57,14 +57,14 @@
 }
 
 .main-popular__container {
-  width: 714px;
+  width: 682px;
   position: relative;
   overflow: hidden;
   display: inline-block;
 }
 .main-popular__booklist {
   margin-top: 56px;
-  margin-left : 390px;
+  margin-left : 370px;
   display: flex;
   justify-content: space-between;
 }
@@ -97,7 +97,7 @@
 }
 
 
-@media screen and (max-width: 1200px) {
+@media screen and (max-width:1200px) {
   /* .main-popular {
     width: 100%;   
     white-space:normal;

--- a/src/css/MainPopular.css
+++ b/src/css/MainPopular.css
@@ -28,7 +28,6 @@
 .main-popular__cover-img {
   width: 342px;
   height: 500px;
-  background-color: #a4a4a4;
 }
 .main-popular__cover-more {
   width: 262.1px;

--- a/src/css/Rent.css
+++ b/src/css/Rent.css
@@ -1,6 +1,6 @@
 .rent-title {
   position: relative;
-  padding: 89px 270px 60px 270px;
+  padding: 89px 150px 60px 150px;
   min-width: 900px;
   height: 107px;
   z-index: 2;
@@ -8,13 +8,13 @@
 
 .rent-subtitle {
   min-width: 900px;
-  padding: 118px 270px 120px 270px;
+  padding: 118px 150px 120px 150px;
   margin: auto;
 }
 
 .inquire-box-wrapper {
-  min-width: 1440px;
-  /* padding: 0 270px 0 270px; */
+  min-width: 1200px;
+  /* padding: 0 150px 0 150px; */
   margin: auto;
   align-items: center;
   margin-bottom: 60px;

--- a/src/css/RentButton.css
+++ b/src/css/RentButton.css
@@ -1,5 +1,5 @@
 .rent-button {
-  min-width: 1440px;
+  min-width: 1200px;
   flex: none;
   display: flex;
   flex-direction: column;

--- a/src/css/ReservedLoan.css
+++ b/src/css/ReservedLoan.css
@@ -1,17 +1,17 @@
 .reservedLoan-main {
-  min-width: 1440px;
+  min-width: 1200px;
   margin: 0px auto;
 }
 .reservedLoan-title {
   position: relative;
-  padding: 89px 270px 60px 270px;
+  padding: 89px 0 60px ;
   min-width: 900px;
   height: 107px;
   z-index: 2;
 }
 .reservedLoan-subtitle {
   min-width: 900px;
-  padding: 118px 270px 120px 270px;
+  padding: 118px 0 120px ;
   margin: auto;
 }
 

--- a/src/css/ReturnBook.css
+++ b/src/css/ReturnBook.css
@@ -1,17 +1,17 @@
 .returnbook-main {
-  min-width: 1440px;
+  min-width: 1200px;
   margin: 0px auto;
 }
 .returnbook-title {
   position: relative;
-  padding: 89px 270px 60px 270px;
+  padding: 89px 150px 60px 150px;
   min-width: 900px;
   height: 107px;
   z-index: 2;
 }
 .returnbook-subtitle {
   min-width: 900px;
-  padding: 118px 270px 120px 270px;
+  padding: 118px 150px 120px 150px;
   margin: auto;
 }
 

--- a/src/css/Search.css
+++ b/src/css/Search.css
@@ -1,6 +1,6 @@
 .wish-book-wraper {
   min-width: 900px;
-  padding: 0 270px 0 270px;
+  padding: 0 150px 0 150px;
   height: 887px;
   display: flex;
   align-items: center;
@@ -8,7 +8,7 @@
 }
 
 .search-section {
-  padding: 0 270px 0 270px;
+  padding: 0 150px 0 150px;
   max-width: 1200px;
   min-width: 900px;
   margin: auto;
@@ -19,7 +19,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 109px 270px 120px 270px;
+  padding: 109px 150px 120px 150px;
   min-width: 900px;
   z-index: 2;
   height: 231px;

--- a/src/img/image_onerror.svg
+++ b/src/img/image_onerror.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="205" height="300" viewBox="0 0 205 300">
+    <style>
+      .cls-1 {
+        fill: rgba(0,0,0,0.2);
+      }
+    </style>
+    <rect id="사각형_7" data-name="사각형 7" class="cls-1" width="205" height="300" />
+</svg>


### PR DESCRIPTION
## description
> 모바일 환경에서 웹서비스를 이용할 수 있도록 최소한의 설정을 수정합니다.
## todo
- [x] 메타태그의 화면축소 옵션 추가
- [x] 기타 css 수정

### 기타
- 지난 프론트회의때 논의된 내용을 바탕으로 수정한 내용입니다. 
- 이용안내 화면의 가독성 개선을 위해 색상을 변경했습니다. 지난 회의때 언급되었던 대로 질문 색상과 답변 색상을 일치시켰습니다.
- 서버에서 불러온 이미지를 노출할 때 onError 옵션을 추가했습니다. 제공된 이미지를 찾을 수 없는 등 오류가 발생하면 회색 이미지로 대체하여 노출합니다. 
- 예약 성공시 대출 가능 예상일자 노출되지 않았던 부분 수정했습니다.
- 예약 예상 순위 fetch 실패시 -1순위로 노출되지 않고 실패모달로 전환하도록 수정했습니다.