### PR TITLE
FEATURE: footer에서도 ScrollTopButton 유지

### DIFF
--- a/src/component/utils/ScrollTopButton.js
+++ b/src/component/utils/ScrollTopButton.js
@@ -7,6 +7,7 @@ const ScrollTopButton = ({ rightRem, bottomRem }) => {
   const [active, setActive] = useState(false);
   const [activeScrollY, setActiveScrollY] = useState(0);
   const [inActiveScrollY, setInActiveScrollY] = useState(0);
+  const [footerShownHeigtRem, setFooterShownHeightRem] = useState(0);
   const onClickBtn = () => {
     window.scrollTo(0, 0);
   };
@@ -26,14 +27,26 @@ const ScrollTopButton = ({ rightRem, bottomRem }) => {
         window.scrollY < inActiveScrollY
       ) {
         setActive(true);
-      } else setActive(false);
+      } else if (window.scrollY >= inActiveScrollY) {
+        setFooterShownHeightRem(
+          window.scrollY +
+            window.innerHeight -
+            (document.body.scrollHeight -
+              document.getElementsByClassName("footer")[0].scrollHeight),
+        );
+      } else {
+        setActive(false);
+      }
     };
     window.addEventListener("scroll", getScrollScope);
     return () => {
       window.removeEventListener("scroll", getScrollScope);
     };
-  }, [activeScrollY, inActiveScrollY]);
+  }, [activeScrollY, inActiveScrollY, footerShownHeigtRem]);
 
+  // rightRem : 사용하는 요소에서의 right
+  // bottomRem : 화면에서의 bottom
+  // footerShownHeight : footer가 화면에 보이는 만큼의 rem
   return (
     <div
       className="scroll-top-button__wrapper"
@@ -41,7 +54,12 @@ const ScrollTopButton = ({ rightRem, bottomRem }) => {
     >
       <button
         className="scroll-top-button__button"
-        style={{ bottom: `${bottomRem}rem` }}
+        style={{
+          bottom: `${
+            parseInt(bottomRem, 10) +
+            (footerShownHeigtRem > 0 ? footerShownHeigtRem * 0.1 : 0)
+          }rem`,
+        }}
         type="button"
         onClick={onClickBtn}
       >


### PR DESCRIPTION
## 1. 활동목표

수지킴님이 말씀하신, 이용 안내 페이지 footer에 화면이 다다르더라도 버튼이 사라지지 않도록 구현합니다.

## 2. 활동사항

**issue #130** 을 해결했습니다. 이제 footer에 도달하더라도 버튼이 사라지지 않습니다. 그 과정에서 window객체와 특정 요소의 크기를 계속해서 업데이트하기 때문에, 수평 반응형도 자동으로 이루어집니다.

### 1) 주요코드

```js
if (
  window.scrollY > activeScrollY / 2 &&
  window.scrollY < inActiveScrollY
) {
  setActive(true);
} else if (window.scrollY >= inActiveScrollY) {
  setFooterShownHeightRem(
    window.scrollY +
      window.innerHeight -
      (document.body.scrollHeight -
        document.getElementsByClassName("footer")[0].scrollHeight),
  );
} else {
  setActive(false);
}
```

여기서 inActiveScrollY에 scrollY가 도달한다면 기존에는 inActive가 되었습니다. 여기서 inActive을 시키지 않고 footer가 나타날 때의 버튼의 위치에서 멈춰있도록 만들었습니다. footerShownHeightRem 이 화면에 footer가 보이는 만큼의 px을 나타냅니다.

### 2) 해결 스크린샷

- 기본 예시

https://user-images.githubusercontent.com/79993356/166447658-307ea5b9-522d-4403-8651-e6fe3c855c40.mov

- 자동으로 반응형 적용

https://user-images.githubusercontent.com/79993356/166448626-cf97f2b2-a3c9-407a-a189-ed798255633e.mov


