### PR TITLE
JIP-190 FIX: SubTitle 케이스 추가, 검색 시 pageRange 초기화

### DIFF
--- a/src/component/search/Search.js
+++ b/src/component/search/Search.js
@@ -135,6 +135,7 @@ const Search = ({ match, location }) => {
     setUserWord(decodeURIComponent(queryString));
     setInputValue(decodeURIComponent(queryString));
     setPage(queryPage);
+    setPageRange(parseInt((queryPage - 1) / 5, 10));
     setSort(querySort);
     setCateIndex(queryCateIndex);
     if (parseInt(queryCateIndex, 10) === 0) setCategoryName("");
@@ -148,7 +149,11 @@ const Search = ({ match, location }) => {
       <section className="search-section">
         <div className="search-subtitle" ref={myRef}>
           <SubTitle
-            subTitle={`'${userWord}' 도서 검색 결과`}
+            subTitle={
+              userWord === ""
+                ? "전체 도서 목록"
+                : `'${userWord}' 도서 검색 결과`
+            }
             alignItems="start"
             description=""
           />


### PR DESCRIPTION
### 1. Search 페이지 Subtitle

- 검색어가 없을시 전체 도서 목록을 반환하므로, Subtitle을 `전체 도서 목록` 으로 표시

<img width="1792" alt="스크린샷 2022-06-22 오후 3 28 54" src="https://user-images.githubusercontent.com/74581396/174958726-a14bdad0-31d8-4931-b5c2-2924f20f8a7f.png">

<br>

### 2. 카테고리나 정렬에 변화가 있을 경우 pageRange를 page에 맞게 초기화

- 이전에는 page가 바뀌어도 pageRange가 바뀌지 않는 경우가 생겨 수정했습니다

<br>
