### PR TITLE
Jip 193 예약 대출 페이지 유지보수

### DIFF
--- a/src/component/mypage/MypageReservedBook.js
+++ b/src/component/mypage/MypageReservedBook.js
@@ -5,7 +5,9 @@ import PropTypes from "prop-types";
 
 const MypageReservedBook = ({ reserveInfo }) => {
   const onClickCancle = async id => {
-    await axios.patch(`${process.env.REACT_APP_API}/reservations/cancel/${id}`);
+    await axios
+      .patch(`${process.env.REACT_APP_API}/reservations/cancel/${id}`)
+      .catch(err => console.log(err));
   };
 
   return (

--- a/src/component/rent/RentModalConfirm.js
+++ b/src/component/rent/RentModalConfirm.js
@@ -99,7 +99,7 @@ const RentModalConfirm = ({
               <div className="rent-modal__remark">
                 <p className="font-16 color-red">비고</p>
                 <textarea
-                  className="mid-modal__remark__input margin-8"
+                  className="mid-modal__remark__input margin-8 font-16"
                   placeholder="비고를 입력해주세요. (반납 시 책 상태 등)"
                   value={index === 0 ? remark1 : remark2}
                   onChange={index === 0 ? handleRemark1 : handleRemark2}

--- a/src/component/reservedloan/ReservedFilter.js
+++ b/src/component/reservedloan/ReservedFilter.js
@@ -5,16 +5,27 @@ import CheckIcon from "../../img/check_icon.svg";
 import RedCheckIcon from "../../img/check_icon_red.svg";
 
 const ReservedFilter = ({
-  isProceeding,
-  setProceeding,
-  isFinish,
-  setFinish,
+  isPending,
+  setIsPending,
+  isExpired,
+  setIsExpired,
+  isWaiting,
+  setIsWaiting,
 }) => {
   const toggleProceeding = () => {
-    setProceeding(!isProceeding);
+    setIsPending(!isPending);
+    setIsWaiting(false);
+    setIsExpired(false);
+  };
+  const toggleWaiting = () => {
+    setIsPending(false);
+    setIsWaiting(!isWaiting);
+    setIsExpired(false);
   };
   const toggleFinish = () => {
-    setFinish(!isFinish);
+    setIsPending(false);
+    setIsWaiting(false);
+    setIsExpired(!isExpired);
   };
   return (
     <div className="reserved-filter">
@@ -26,15 +37,33 @@ const ReservedFilter = ({
         >
           <img
             className="filter__icon"
-            src={`${isProceeding ? RedCheckIcon : CheckIcon}`}
+            src={`${isPending ? RedCheckIcon : CheckIcon}`}
             alt="check"
           />
           <span
             className={`proceeding-finsh__text font-16-bold ${
-              isProceeding ? "color-red" : "color-a4"
+              isPending ? "color-red" : "color-a4"
             }`}
           >
-            진행중 예약 보기
+            대출 대기 중
+          </span>
+        </button>
+        <button
+          type="button"
+          onClick={toggleWaiting}
+          className="finish filter-button"
+        >
+          <img
+            className="filter__icon"
+            src={`${isWaiting ? RedCheckIcon : CheckIcon}`}
+            alt="check"
+          />
+          <span
+            className={`proceeding-finish__text font-16-bold ${
+              isWaiting ? "color-red" : "color-a4"
+            }`}
+          >
+            예약 배정 대기 중
           </span>
         </button>
         <button
@@ -44,15 +73,15 @@ const ReservedFilter = ({
         >
           <img
             className="filter__icon"
-            src={`${isFinish ? RedCheckIcon : CheckIcon}`}
+            src={`${isExpired ? RedCheckIcon : CheckIcon}`}
             alt="check"
           />
           <span
             className={`proceeding-finish__text font-16-bold ${
-              isFinish ? "color-red" : "color-a4"
+              isExpired ? "color-red" : "color-a4"
             }`}
           >
-            종료된 예약 보기
+            종료된 예약
           </span>
         </button>
       </div>

--- a/src/component/reservedloan/ReservedFilter.js
+++ b/src/component/reservedloan/ReservedFilter.js
@@ -69,7 +69,7 @@ const ReservedFilter = ({
         <button
           type="button"
           onClick={toggleFinish}
-          className="finish filter-button"
+          className=" finish filter-button "
         >
           <img
             className="filter__icon"

--- a/src/component/reservedloan/ReservedLoan.js
+++ b/src/component/reservedloan/ReservedLoan.js
@@ -11,7 +11,6 @@ import ReservedFilter from "./ReservedFilter";
 import ReservedTableList from "./ReservedTableList";
 import ReservedModal from "./ReservedModal";
 import AdminTabs from "../utils/AdminTabs";
-// import PropTypes from "prop-types";
 
 const ReservedLoan = () => {
   const [modal, setModal] = useState(false);
@@ -21,8 +20,9 @@ const ReservedLoan = () => {
   const [resevedLoanPageRange, setResevedLoanPageRange] = useState(0);
   const [lastresevedLoanPage, setLastresevedLoanPage] = useState(1);
   const [reservedLoanList, setReservedLoanList] = useState([]);
-  const [isProceeding, setProceeding] = useState(true);
-  const [isFinish, setFinish] = useState(false);
+  const [isPending, setIsPending] = useState(false);
+  const [isWaiting, setIsWaiting] = useState(false);
+  const [isExpired, setIsExpired] = useState(false);
   const [reservedInfo, setReservedInfo] = useState(null);
 
   const openModal = () => {
@@ -43,10 +43,10 @@ const ReservedLoan = () => {
   };
 
   const filterState = () => {
-    if (isProceeding && isFinish) return "proceeding,finish";
-    if (isProceeding) return "proceeding";
-    if (isFinish) return "finish";
-    return "proceeding";
+    if (isPending) return "pending";
+    if (isWaiting) return "waiting";
+    if (isExpired) return "expired";
+    return "all";
   };
 
   const fetchReservedLoanData = async () => {
@@ -55,7 +55,7 @@ const ReservedLoan = () => {
     } = await axios.get(`${process.env.REACT_APP_API}/reservations/search`, {
       params: {
         query: userSearchWord,
-        page: resevedLoanPage,
+        page: resevedLoanPage - 1,
         limit: 5,
         filter: filterState(),
       },
@@ -71,8 +71,8 @@ const ReservedLoan = () => {
   useEffect(fetchReservedLoanData, [
     userSearchWord,
     resevedLoanPage,
-    isProceeding,
-    isFinish,
+    isPending,
+    isExpired,
   ]);
 
   useEffect(() => {
@@ -82,11 +82,19 @@ const ReservedLoan = () => {
       searchForm.removeEventListener("submit", handleReservedLoanSumbit);
   }, [handleReservedLoanSumbit]);
 
+  useEffect(() => {
+    setResevedLoanPage(1);
+    setResevedLoanPageRange(0);
+    setResevedLoanPageRange(0);
+  }, [isPending, isWaiting, isExpired]);
+
   const tabList = [
     { name: "대출", link: "/rent" },
     { name: "예약대출", link: "/reservation" },
     { name: "반납", link: "/return" },
   ];
+
+  console.log(reservedInfo);
 
   return (
     <main>
@@ -104,15 +112,19 @@ const ReservedLoan = () => {
         <div className="reserved-loan-table__inquire-box">
           <div className="reserved-loan-filter">
             <ReservedFilter
-              isProceeding={isProceeding}
-              setProceeding={setProceeding}
-              isFinish={isFinish}
-              setFinish={setFinish}
+              isPending={isPending}
+              setIsPending={setIsPending}
+              isExpired={isExpired}
+              setIsExpired={setIsExpired}
+              isWaiting={isWaiting}
+              setIsWaiting={setIsWaiting}
             />
           </div>
           {reservedLoanList.map(factor => (
             <ReservedTableList
               key={factor.id}
+              isPending={isPending}
+              isWaiting={isWaiting}
               factor={factor}
               openModal={openModal}
               setInfo={setReservedInfo}

--- a/src/component/reservedloan/ReservedLoan.js
+++ b/src/component/reservedloan/ReservedLoan.js
@@ -94,8 +94,6 @@ const ReservedLoan = () => {
     { name: "반납", link: "/return" },
   ];
 
-  console.log(reservedInfo);
-
   return (
     <main>
       <Banner img="admin" titleKo="예약 대출" titleEn="BOOK RESERVATION" />

--- a/src/component/reservedloan/ReservedModal.js
+++ b/src/component/reservedloan/ReservedModal.js
@@ -19,13 +19,13 @@ const ReservedModal = ({ reservedInfo, closeModal }) => {
 
   return (
     <>
-      {miniModalContents ? (
+      {miniModalContents.length ? (
         <MiniModal closeModal={closeMiniModal}>
           {lendResult ? (
             <ModalContentsTitleWithMessage
               closeModal={closeMiniModal}
               title="대출이 완료되었습니다."
-              message={reservedInfo.book.info.title}
+              message={reservedInfo.title}
             />
           ) : (
             <ModalContentsOnlyTitle
@@ -38,7 +38,6 @@ const ReservedModal = ({ reservedInfo, closeModal }) => {
         <MidModal closeModal={closeModal}>
           <ReservedModalContents
             reservedInfo={reservedInfo}
-            closeModal={closeModal}
             setMiniModalContents={setMiniModalContents}
             setLendResult={setLendResult}
           />

--- a/src/component/reservedloan/ReservedModalContents.js
+++ b/src/component/reservedloan/ReservedModalContents.js
@@ -23,8 +23,8 @@ const ReservedModalContents = ({
     await axios
       .post(`${process.env.REACT_APP_API}/lendings`, [
         {
-          userId: reservedInfo.user.id,
-          bookId: reservedInfo.book.id,
+          userId: reservedInfo.userId,
+          bookId: reservedInfo.bookId,
           condition,
         },
       ])

--- a/src/component/reservedloan/ReservedModalContents.js
+++ b/src/component/reservedloan/ReservedModalContents.js
@@ -6,7 +6,6 @@ import getErrorMessage from "../utils/error";
 
 const ReservedModalContents = ({
   reservedInfo,
-  closeModal,
   setMiniModalContents,
   setLendResult,
 }) => {
@@ -45,11 +44,32 @@ const ReservedModalContents = ({
       });
   };
 
+  const deleteReservation = async () => {
+    await axios
+      .patch(
+        `${process.env.REACT_APP_API}/reservations/cancle/${reservedInfo.reservationsId}`,
+      )
+      .then(() => {
+        setMiniModalContents("success");
+        setLendResult(true);
+      })
+      .catch(error => {
+        if (!error.response) return;
+        const { status } = error.response;
+        setLendResult(false);
+        setMiniModalContents(
+          status === 400
+            ? getErrorMessage("lendings", error.response.data.errorCode)
+            : error.message,
+        );
+      });
+  };
+
   return (
     <div className="modal__wrapper mid">
       <div className="mid-modal__cover">
         <img
-          src={reservedInfo.book.info.image}
+          src={reservedInfo.image}
           alt="cover"
           className="mid-modal__cover-img"
         />
@@ -58,9 +78,9 @@ const ReservedModalContents = ({
         <div className="mid-modal__book">
           <p className="font-16 color-red">도서정보</p>
           <p className="mid-modal__book-title font-28-bold color-54  margin-8">
-            {reservedInfo.book.info.title}
+            {reservedInfo.title}
           </p>
-          <p className="font-16 color-54">{`도서코드 : ${reservedInfo.book.callSign}`}</p>
+          <p className="font-16 color-54">{`도서코드 : ${reservedInfo.callSign}`}</p>
         </div>
         <div className="mid-modal__lend">
           <p className="font-16 color-red">예약 만료일</p>
@@ -71,14 +91,14 @@ const ReservedModalContents = ({
         <div className="mid-modal__user">
           <p className="font-16 color-red">유저정보</p>
           <p className="font-28-bold color-54  margin-8">
-            {reservedInfo.user.login}
+            {reservedInfo.login}
           </p>
-          <p className="font-16 color-54">{`연체일수 : ${reservedInfo.user.penaltyDays}`}</p>
+          <p className="font-16 color-54">{`연체일수 : ${reservedInfo.penaltyDays}`}</p>
         </div>
         <div className="mid-modal__remark">
           <p className="font-16 color-red">비고</p>
           <textarea
-            className="mid-modal__remark__input margin-8"
+            className="mid-modal__remark__input margin-8 font-16"
             placeholder="비고를 입력해주세요. (반납 시 책 상태 등)"
             value={remark}
             onChange={handleRemark}
@@ -96,9 +116,9 @@ const ReservedModalContents = ({
             <button
               className="modal__button mid font-20 color-ff"
               type="button"
-              onClick={closeModal}
+              onClick={deleteReservation}
             >
-              취소하기
+              예약취소
             </button>
           </div>
         </div>
@@ -108,7 +128,6 @@ const ReservedModalContents = ({
 };
 
 ReservedModalContents.propTypes = {
-  closeModal: PropTypes.func.isRequired,
   reservedInfo: PropTypes.object.isRequired,
   setMiniModalContents: PropTypes.func.isRequired,
   setLendResult: PropTypes.func.isRequired,

--- a/src/component/reservedloan/ReservedTableList.js
+++ b/src/component/reservedloan/ReservedTableList.js
@@ -3,16 +3,24 @@ import React from "react";
 import "../../css/ReservedTableList.css";
 import Arr from "../../img/arrow_right_black.svg";
 
-const ReservedTableList = ({ factor, openModal, setInfo }) => {
+const ReservedTableList = ({
+  isPending,
+  isWaiting,
+  factor,
+  openModal,
+  setInfo,
+}) => {
   const openSetModal = () => {
     setInfo(factor);
     openModal();
   };
 
+  // console.log(factor && factor.endAt && factor.endAt.slice(0, 10));
+
   return (
     <div className="reserved-loan__table-list">
       <div className="reserved-loan__table-list__name font-18-bold color-54">
-        {factor.user && factor.user.login}
+        {factor && factor.login}
       </div>
       <button
         className="reserved-loan__table-list__button"
@@ -21,7 +29,7 @@ const ReservedTableList = ({ factor, openModal, setInfo }) => {
       >
         <div className="reserved-loan__table-list__title">
           <span className="reserved-loan__table-list__text font-18-bold color-54">
-            {factor.book && factor.book.info && factor.book.info.title}
+            {factor && factor.title}
           </span>
           <img
             className="reserved-loan__table-list__arr"
@@ -31,12 +39,15 @@ const ReservedTableList = ({ factor, openModal, setInfo }) => {
         </div>
         <div className="reserved-loan__table-list__info">
           <span className="reserved-loan__table-list__call-sign font-16 color-54">
-            도서등록번호 : {factor.book && factor.book.callSign}
+            도서등록번호 : {factor && factor.callSign}
           </span>
           <span className="font-16 color-54">
-            {factor.book &&
-              factor.book.lendings[0] &&
-              `반납 예정일 : ${factor.book.lendings[0].dueDate}`}
+            {factor && factor.endAt && isPending
+              ? `예약 만료일 : ${factor.endAt.slice(0, 10)}`
+              : null}
+            {factor && factor.createdAt && isWaiting
+              ? `예약 시작일 : ${factor.createdAt.slice(0, 10)}`
+              : null}
           </span>
         </div>
       </button>

--- a/src/component/return/ReturnModalContents.js
+++ b/src/component/return/ReturnModalContents.js
@@ -88,7 +88,7 @@ const ReturnModalContents = ({
         <div className="mid-modal__remark">
           <p className="font-16 color-red">비고</p>
           <textarea
-            className="mid-modal__remark__input margin-8"
+            className="mid-modal__remark__input margin-8 font-16"
             placeholder={`대출당시 : ${data.condition}`}
             value={remark}
             onChange={handleRemark}

--- a/src/css/AdminSearchBar.css
+++ b/src/css/AdminSearchBar.css
@@ -48,3 +48,23 @@ button:focus {
   width: 2.8rem;
   height: 2.8rem;
 }
+
+@media screen and (max-width: 1200px) {
+  .modal-search-form {
+    height: 5.4rem;
+  }
+  .modal-search__icon {
+    width: 2.4rem;
+    height: 2.4rem;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .modal-search-form {
+    height: 4.4rem;
+  }
+  .modal-search__icon {
+    width: 2rem;
+    height: 2rem;
+  }
+}

--- a/src/css/EditEmail.css
+++ b/src/css/EditEmail.css
@@ -48,6 +48,7 @@
   border: none;
   border-bottom: 1px solid;
   text-align: center;
+  background: none;
 }
 
 .mypage-edit-email-button {

--- a/src/css/EditPassword.css
+++ b/src/css/EditPassword.css
@@ -41,6 +41,7 @@
   border: none;
   border-bottom: 1px solid;
   text-align: center;
+  background: none;
 }
 
 .mypage-edit-pw-check_pw {
@@ -55,6 +56,7 @@
   border: none;
   border-bottom: 1px solid;
   text-align: center;
+  background: none;
 }
 
 .mypage-edit-pw-button {

--- a/src/css/InquireBoxTitle.css
+++ b/src/css/InquireBoxTitle.css
@@ -27,11 +27,16 @@
 @media screen and (max-width: 1200px) {
   .inquire-box-title {
     width: 100%;
-  }  
+    height: 8rem;
+  }
 }
 
 @media screen and (max-width: 767px) {
+  .inquire-box-title {
+    height: 6rem;
+  }
   .inquire-box-title__icon.short {
+    height: 3rem;
     margin-left: 4rem;
   }
   .inquire-box-title__text.short {

--- a/src/css/MidModal.css
+++ b/src/css/MidModal.css
@@ -57,9 +57,15 @@
 }
 
 .modal__buttons {
-  margin-top:4rem;
+  margin-top: 4rem;
   display: flex;
   justify-content: center;
+}
+
+@media screen and (max-width: 1200px) {
+  .mid-modal__book-title {
+    font-size: 2.4rem;
+  }
 }
 
 @media screen and (max-width: 767px) {
@@ -70,7 +76,7 @@
 
   .mid-modal__cover {
     float: none;
-    margin:auto;
+    margin: auto;
     width: 137px;
     height: 200px;
   }
@@ -78,14 +84,19 @@
     width: 137px;
     height: 200px;
   }
-  
+
   .mid-modal__book {
     margin-bottom: 1.8rem;
   }
   .mid-modal__book-title {
-
     max-height: 6rem;
-}
+  }
+  .mid-modal__detail {
+    margin-bottom: 2rem;
+  }
+  .mid-modal__lend {
+    width: 30%;
+  }
 
   .modal__wrapper .font-28-bold {
     font-size: 2rem;
@@ -93,11 +104,10 @@
 
   .modal__wrapper .font-16 {
     font-size: 1.4rem;
-
   }
 
-  .margin-8 { 
-    margin:0;
+  .margin-8 {
+    margin: 0;
   }
   .mid-modal__remark__input {
     height: 50px;

--- a/src/css/Modal.css
+++ b/src/css/Modal.css
@@ -58,5 +58,7 @@
 @media screen and (max-width: 1200px) {
   .modal__container {
     width: 100%;
+    height: 100%;
+    overflow-y: scroll;
   }
 }

--- a/src/css/ReservedFilter.css
+++ b/src/css/ReservedFilter.css
@@ -29,3 +29,20 @@
 .filter__icon {
   margin-right: 1.2rem;
 }
+
+@media screen and (max-width: 480px) {
+  .reserved-filter-wrapper {
+    display: flex;
+    flex-direction: column;
+    align-items: baseline;
+    margin-bottom: 0;
+  }
+
+  .filter-button {
+    text-align: end;
+    margin-bottom: 1rem;
+  }
+  .finish {
+    margin-left: 0rem !important;
+  }
+}

--- a/src/css/ReservedFilter.css
+++ b/src/css/ReservedFilter.css
@@ -1,11 +1,11 @@
 .reserved-filter {
-  padding-right: 6.8rem;
+  padding-right: 3rem;
+  display: flex;
+  justify-content: flex-end;
 }
 
 .reserved-filter-wrapper {
-  width: 30rem;
   margin-top: 3rem;
-  margin-left: auto;
   margin-bottom: 2rem;
 }
 

--- a/src/css/ReservedLoan.css
+++ b/src/css/ReservedLoan.css
@@ -3,14 +3,14 @@
 }
 .reserved-loan-title {
   position: relative;
-  padding: 8.9rem 0 6rem ;
+  padding: 8.9rem 0 6rem;
   min-width: 90rem;
   height: 10.7rem;
   z-index: 2;
 }
 .reserved-loan-subtitle {
   min-width: 90rem;
-  padding: 11.8rem 0 12rem ;
+  padding: 11.8rem 0 12rem;
   margin: auto;
 }
 
@@ -33,8 +33,24 @@
   margin-top: 3.6rem;
 }
 
-@media screen and (max-width: 120rem) {
+.inquire-box-title__kr {
+  font-size: 2.2rem;
+}
+
+.inquire-box-title__en {
+  font-size: 1.4rem;
+}
+
+@media screen and (max-width: 1200px) {
   .reserved-loan-table__inquire-box {
-    width:100%;
-  }  
+    width: 100%;
+    top: -11rem;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .reserved-loan-table__inquire-box {
+    padding-top: 3rem;
+    top: -9rem;
+  }
 }

--- a/src/css/ReservedTableList.css
+++ b/src/css/ReservedTableList.css
@@ -1,7 +1,7 @@
 .reserved-loan__table-list {
   display: flex;
-  width: 108rem;
-  margin-left: auto;
+  margin-left: 6rem;
+  margin-right: 3rem;
   padding-top: 4rem;
 }
 
@@ -12,7 +12,7 @@
   border: 0;
   padding: 0;
   text-align: left;
-  border-bottom:0.1rem solid #a4a4a4;
+  border-bottom: 0.1rem solid #a4a4a4;
   padding-bottom: 4rem;
   cursor: pointer;
 }
@@ -26,14 +26,17 @@
 }
 
 .reserved-loan__table-list__arr {
-  width:0.8rem;
+  width: 0.8rem;
   height: 1.6rem;
   margin-right: 4rem;
   margin-left: auto;
 }
 
 .reserved-loan__table-list__name {
-  width: 16.1rem;
+  width: 12.1rem;
+  padding-right: 4rem;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
 
 .reserved-loan__table-list__info {
@@ -44,17 +47,17 @@
   margin-right: 2.8rem;
 }
 
-@media screen and (max-width:1200px) {
+/* @media screen and (max-width: 1200px) {
   .reserved-loan__table-list {
     width: 90%;
   }
-}
+} */
 
-@media screen and (max-width:767px) {
+@media screen and (max-width: 767px) {
   .reserved-loan__table-list {
     display: block;
   }
-  
+
   .reserved-loan__table-list__name {
     margin-bottom: 1.1rem;
   }
@@ -66,7 +69,7 @@
   }
 }
 
-@media screen and (max-width:480px) {
+@media screen and (max-width: 480px) {
   .reserved-loan__table-list__info > span {
     display: block;
     font-size: 1.4rem;


### PR DESCRIPTION
## 1. 기존에 있던 Search Fileter을 교체

기존에는 `진행중인 예약`과 `종료된 예약`만이 존재했다면, 지금은 분류에 따라 세 가지의 필터로 나뉘도록 설정했습니다.

(설정명이 괜찮은지 확인해주시면 감사하겠습니다!)

![image](https://user-images.githubusercontent.com/79993356/175355453-e9db42f1-fa2a-4cda-a53a-1a3673255db4.png)

## 2. 예약 대출 검색 결과에 예약 취소 추가

원래는 해당 버튼이 그냥 취소 버튼이며, 클릭 시에는 모달이 닫히는 기능을 했습니다.

이를 예약 취소로 변경해, `사서가 예약을 취소할 수도 있도록` 정했습니다.

![image](https://user-images.githubusercontent.com/79993356/175355771-4ad52e80-07b6-4a5d-8e68-26a111c28aba.png)
