### PR TITLE
Jip 195 도서 상세페이지에서의 예약 수정

### DIFF
--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -22,14 +22,13 @@ const BookDetail = ({ location, match }) => {
   const [miniModalClosable, setMiniModalClosable] = useState(true);
   const user = useRecoilValue(userState);
 
+  // eslint-disable-next-line no-unused-vars
   const getHost = () => {
     return `${window.location.protocol}//${window.location.host}`;
   };
   const openModal = () => {
     if (!user.isLogin) {
-      window.location = `${
-        process.env.REACT_APP_API
-      }/auth/oauth?clientURL=${getHost()}`;
+      window.location = `/login`;
       return;
     }
     setMiniModalView(true);

--- a/src/component/book/BookStatus.js
+++ b/src/component/book/BookStatus.js
@@ -1,102 +1,28 @@
+/* eslint-disable no-unused-vars */
 /* eslint-disable react/prop-types */
-import React, { useState } from "react";
-import { useRecoilValue } from "recoil";
-import userState from "../../atom/userState";
+import React from "react";
 import "../../css/BookStatus.css";
-import ArrRes from "../../img/arrow_right_res.svg";
-import ArrDef from "../../img/arrow_right_res_default.svg";
-import MiniModal from "../utils/MiniModal";
-import Reservation from "../reservation/Reservation";
 
-const BookStatus = ({ id, callSign, dueDate, status, index }) => {
-  const [miniModalView, setMiniModalView] = useState(false);
-  const [miniModalClosable, setMiniModalClosable] = useState(true);
-  const user = useRecoilValue(userState);
-  const [mobileToggle, setMobileToggle] = useState(false);
-
-  const handleToggle = () => {
-    setMobileToggle(!mobileToggle);
-  };
-
-  const getHost = () => {
-    return `${window.location.protocol}//${window.location.host}`;
-  };
-  const openModal = () => {
-    if (dueDate === "-") {
-      return;
-    }
-    if (!user.isLogin) {
-      window.location = `${
-        process.env.REACT_APP_API
-      }/auth/oauth?clientURL=${getHost()}`;
-      return;
-    }
-    setMiniModalView(true);
-  };
-
-  const closeModal = () => {
-    if (miniModalClosable) setMiniModalView(false);
-  };
-
+const BookStatus = ({ book, index }) => {
   const doubleDigit = number => {
     return number < 10 ? `0${number}` : `${number}`;
   };
+
+  const getBookStatus = (isLendable, dueDate) => {
+    if (dueDate !== "-") return "대출 중";
+    if (isLendable) return "비치 중";
+    return "대출 불가";
+  };
+
+  console.log("book", book);
   return (
     <div className="book-status color-54">
       <div className="book-status__id font-16">{doubleDigit(index + 1)}</div>
-      <div className="book-status__callSign font-16">{callSign}</div>
-      <div className="book-status__status font-16">{status}</div>
-      <div className="book-status__dueDate font-16">{dueDate}</div>
-      <button
-        type="button"
-        className={`reservation-btn font-16 ${
-          dueDate === "-" ? "color-a4" : "color-red cursor-pointer"
-        }`}
-        onClick={openModal}
-        disabled={dueDate === "-"}
-      >
-        <span>{dueDate === "-" ? "예약 불가" : "예약 하기"}</span>
-      </button>
-      <div
-        className="book-status__toggle"
-        onClick={handleToggle}
-        aria-hidden="true"
-      >
-        <img
-          className={
-            mobileToggle
-              ? "book-status__toggle-img-clicked"
-              : "book-status__toggle-img"
-          }
-          src={dueDate === "-" ? ArrDef : ArrRes}
-          alt="Arr"
-        />
+      <div className="book-status__callSign font-16">{book.callSign}</div>
+      <div className="book-status__status font-16">
+        {getBookStatus(book.isLendable, book.dueDate)}
       </div>
-      {miniModalView && (
-        <MiniModal closeModal={closeModal}>
-          <Reservation
-            bookId={id}
-            closeModal={closeModal}
-            setClosable={setMiniModalClosable}
-          />
-        </MiniModal>
-      )}
-      <div
-        className={
-          mobileToggle
-            ? "book-status__mobile-info"
-            : "book-status__mobile-info-hidden"
-        }
-      >
-        <p className="book-status__mobile-info-item">
-          <span>청구기호</span>
-          <span>{callSign}</span>
-        </p>
-        <p className="book-status__mobile-info-item">
-          <span>반납 예정일</span>
-          <span>{dueDate}</span>
-        </p>
-      </div>
+      <div className="book-status__dueDate font-16">{book.dueDate}</div>
     </div>
   );
 };

--- a/src/component/reservation/Reservation.js
+++ b/src/component/reservation/Reservation.js
@@ -6,14 +6,14 @@ import getErrorMessage from "../utils/error";
 import SuccessRsv from "./SuccessRsv";
 import ModalContentsOnlyTitle from "../utils/ModalContentsTitleWithMessage";
 
-const Reservation = ({ bookId, closeModal, setClosable }) => {
+const Reservation = ({ bookInfoId, closeModal, setClosable }) => {
   const [reservationStep, setReservationStep] = useState("waitUserConfirm");
   const [propsNumber, setPropsNumber] = useState(-1);
   const [propsString, setPropsString] = useState("");
   const postReservation = async () => {
     await axios
-      .post(`${process.env.REACT_APP_API}/reservations/`, {
-        bookId,
+      .post(`${process.env.REACT_APP_API}/reservations`, {
+        bookInfoId,
       })
       .then(response => {
         setPropsNumber(response.data.count);
@@ -47,7 +47,7 @@ const Reservation = ({ bookId, closeModal, setClosable }) => {
       case "waitUserConfirm":
         return (
           <UserConfirm
-            bookId={bookId}
+            bookInfoId={bookInfoId}
             closeModal={closeModal}
             onConfirm={tryReservation}
             setReservationStep={setReservationStep}

--- a/src/component/reservation/UserConfirm.js
+++ b/src/component/reservation/UserConfirm.js
@@ -3,7 +3,7 @@ import axios from "axios";
 import PropTypes from "prop-types";
 
 const UserConfirm = ({
-  bookId,
+  bookInfoId,
   closeModal,
   onConfirm,
   setReservationStep,
@@ -12,7 +12,9 @@ const UserConfirm = ({
   const [expectedRank, setExpectedRank] = useState(-1);
   useEffect(() => {
     axios
-      .get(`${process.env.REACT_APP_API}/books/${bookId}/reservations/count/`)
+      .get(
+        `${process.env.REACT_APP_API}/reservations/count?bookInfo=${bookInfoId}`,
+      )
       .then(response => {
         setExpectedRank(response.data.count);
       })
@@ -63,7 +65,7 @@ const UserConfirm = ({
 export default UserConfirm;
 
 UserConfirm.propTypes = {
-  bookId: PropTypes.number.isRequired,
+  bookInfoId: PropTypes.number.isRequired,
   closeModal: PropTypes.func.isRequired,
   onConfirm: PropTypes.func.isRequired,
   setReservationStep: PropTypes.func.isRequired,

--- a/src/css/BookDetail.css
+++ b/src/css/BookDetail.css
@@ -1,13 +1,39 @@
 .book-detail-body {
   max-width: 100rem;
   position: relative;
-  margin: 6rem auto;
+  margin: auto;
+  margin-top: 7rem;
+  margin-bottom: 10rem;
+}
+
+.book-detail__reservation-button {
+  display: flex;
+  /* flex-direction: column; */
+  margin-bottom: 2.4rem;
+  flex-wrap: wrap;
+  justify-content: space-between;
+}
+
+.book-detail__reservation-button img {
+  height: 1.3rem;
+  margin: 0 1rem 0 1rem;
+}
+
+.reservation-active-button {
+  all: unset;
+  cursor: pointer;
+  margin-top: 1rem;
+}
+
+.reservation-disable-button {
+  all: unset;
+  margin-top: 1rem;
 }
 
 .breadcrumb {
   display: flex;
   justify-content: flex-end;
-  margin-top: 12rem;
+  /* margin-top: 12rem; */
   margin-right: 3rem;
 }
 
@@ -19,6 +45,8 @@
 
 .book-detail__photo {
   margin: 0 4.8rem 0 0;
+  display: flex;
+  flex-direction: column;
 }
 
 .book-detail__photo img {
@@ -38,13 +66,11 @@
 
 .book-detail__title {
   width: auto;
-  height: 4.1rem;
   font-size: 2.8rem;
   font-weight: bold;
-  margin-top: 0.8rem;
-  margin-bottom: 2.4rem;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  word-wrap: break-all;
+  white-space: normal;
+  padding-right: 2rem;
 }
 
 .book-detail__info {
@@ -91,8 +117,7 @@
   margin-top: 2rem;
 }
 
-@media screen and (min-width:768px) and (max-width: 1200px) {
-
+@media screen and (min-width: 768px) and (max-width: 1200px) {
   .book-detail {
     width: 55%;
     margin-right: auto;
@@ -110,17 +135,17 @@
   .book-detail__info-value {
     margin-left: 4rem;
   }
-
 }
 
-@media screen and (max-width:767px){
-
+@media screen and (max-width: 767px) {
   .book-detail-body {
     padding: 0;
     width: 100%;
     min-width: 36rem;
     position: relative;
-    margin: 0 auto;
+    margin: auto;
+    margin-top: 5rem;
+    margin-bottom: 5rem;
   }
 
   .breadcrumb span {
@@ -130,6 +155,7 @@
 
   .book-content {
     display: block;
+	margin-top: 3rem;
   }
 
   .book-detail__photo {
@@ -185,5 +211,4 @@
   .book-state > span {
     font-size: 2rem;
   }
-
 }

--- a/src/css/BookStatus.css
+++ b/src/css/BookStatus.css
@@ -11,16 +11,19 @@
 .book-status__callSign {
   margin-right: 4%;
   width: 10rem;
+  text-align: center;
 }
 
 .book-status__status {
   margin-right: 5%;
   width: 6rem;
+  text-align: center;
 }
 
 .book-status__dueDate {
   width: 5rem;
   margin-right: 5%;
+  text-align: center;
 }
 
 .reservation-btn, .book-status__toggle {
@@ -44,90 +47,4 @@
 .book-status__toggle-img-clicked {
   margin-left: 1.2rem;
   margin-top: 0.3rem;
-}
-
-.book-status__mobile-info {
-  display: none;
-}
-
-.book-status__mobile-info-hidden {
-  display: none;
-}
-
-@media screen and (max-width:767px) {
-
-  .book-status__callSign{
-    display: none;
-  }
-
-  .book-status__dueDate{
-    display: none;
-  }
-
-  .book-status {
-    flex-wrap: wrap;
-    padding: 1rem 0;
-    margin-bottom: 0;
-    border-bottom: 0.1rem dotted black;
-  }
-
-  .book-status div {
-    margin: auto 0;
-    padding-right: 2rem;
-    font-size: 2rem;
-  }
-
-  .book-status__toggle {
-    margin-left: auto !important;
-    width: 1.8rem;
-  }
-
-  .book-status__toggle-img {
-    width: 100%;
-    cursor: pointer;
-    transform: rotate(90deg);
-    margin-left: 0;
-    margin-top: 1rem;
-  }
-
-  .book-status__toggle-img-clicked {
-    width: 100%;
-    cursor: pointer;
-    transform: rotate(270deg);
-    margin-left: 0;
-    margin-top: 1rem;
-  }
-
-  .book-status__mobile-info {
-    display: block;
-    height: auto;
-    width: 100%;
-  }
-
-  .book-status__mobile-info-hidden {
-    display: none;
-  }
-
-  .book-status__mobile-info-item {
-    margin-top: 1.5rem;
-  }
-
-  .book-status__mobile-info-item span:first-child{
-    font-weight: bolder;
-    margin-left: 10%;
-  }
-
-  .book-status__mobile-info-item span:nth-child(2){
-    position: absolute;
-    left: 50%;
-  }
-
-  .book-status > .reservation-btn {
-    margin: 0.4rem 0 0 2rem;
-  }
-
-  .book-status > .reservation-btn > span {
-    font-size: 2rem;
-  }
-
 }

--- a/src/css/MidModal.css
+++ b/src/css/MidModal.css
@@ -31,9 +31,10 @@
   width: 100%;
   overflow: hidden;
   max-height: 8.1rem;
-  text-overflow: ellipsis;
+  /* text-overflow: ellipsis; */
   word-wrap: break-all;
   white-space: normal;
+  word-break: break-all;
 }
 
 .mid-modal__lend {


### PR DESCRIPTION
### 1. reservation post api 변화 대응
- 요청보내는 주소와 바디에 실어보내는 파라미터를 변경하였습니다.
- 예약을 bookId가 아니라 bookInfoId에 겁니다.

### 2. 상세페이지 디자인 변경
- 예약을 bookId가 아니라 bookInfoId에 걸게 됨에 따라 상세페이지 `예약하기` 및 `예약불가` 버튼의 위치를 변경하였습니다.
- 버튼의 위치가 변경되면서 공간이 확보되어 모바일 화면의 도서 상태목록도 pc 화면과 동일하게 보입니다.

![스크린샷 2022-06-24 오전 2 56 45](https://user-images.githubusercontent.com/74581396/175364047-ab6037a1-bfcc-4ecf-b005-074ce92462d4.png)
![스크린샷 2022-06-24 오전 2 57 06](https://user-images.githubusercontent.com/74581396/175364055-c68b4ddd-fb75-4909-a98a-33283dbce3a2.png)
![스크린샷 2022-06-24 오전 3 02 20](https://user-images.githubusercontent.com/74581396/175365000-4d5695d4-c72e-472f-b13d-72047ec8cb85.png)