### PR TITLE
Jip 224 마이페이지 및 예약 대출 css 수정

### DIFF
--- a/src/component/mypage/EditEmail.js
+++ b/src/component/mypage/EditEmail.js
@@ -25,9 +25,7 @@ function EditEmail() {
     e.preventDefault();
     await axios
       .patch(`${process.env.REACT_APP_API}/users/myupdate`, {
-        params: {
-          email: newEmail,
-        },
+        email: newEmail,
       })
       .then(() => {
         history.goBack();

--- a/src/component/mypage/EditPassword.js
+++ b/src/component/mypage/EditPassword.js
@@ -56,9 +56,14 @@ function EditPassword() {
           </button>
         </div>
         <div className="mypage-edit-pw-title">
-          <span>{`${
-            JSON.parse(window.localStorage.getItem("user")).userId
-          }님의, 비밀번호 변경 페이지입니다`}</span>
+          <p className="margin-bottom-2rem">
+            <span className="font-22-bold">{`${
+              JSON.parse(window.localStorage.getItem("user")).userId
+            }님의, `}</span>
+            <span className="font-22-bold inline-block">
+              비밀번호 변경 페이지입니다
+            </span>
+          </p>
         </div>
         <div className="mypage-edit-pw-new_pw">
           <span className="font-14-bold">새로운 비밀번호</span>
@@ -86,6 +91,9 @@ function EditPassword() {
             />
           </div>
           <div className="mypage-edit-pw-button">
+            <p className="font-12 color-2d">
+              10 ~ 42 글자 사이, 숫자와 특수 기호 1개 포함해주세요
+            </p>
             <button className="font-14" type="submit">
               변경
             </button>

--- a/src/component/mypage/EditPassword.js
+++ b/src/component/mypage/EditPassword.js
@@ -30,9 +30,7 @@ function EditPassword() {
     }
     await axios
       .patch(`${process.env.REACT_APP_API}/users/myupdate`, {
-        params: {
-          password: newPw,
-        },
+        password: newPw,
       })
       .then(() => {
         history.goBack();

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -33,10 +33,10 @@ const Mypage = () => {
               rtnObj.role = "카뎃";
               break;
             case 2:
-              rtnObj.role = "운영진";
+              rtnObj.role = "사서";
               break;
             case 3:
-              rtnObj.role = "사서";
+              rtnObj.role = "운영진";
               break;
             default:
               rtnObj.role = "미인증";
@@ -75,7 +75,7 @@ const Mypage = () => {
             <div>
               <div className="mypage-subtitle__titlebox__title">
                 <span className="color-2d">
-                  {userInfo
+                  {userInfo && userInfo.email
                     ? `${
                         userInfo.nickname ? userInfo.nickname : userInfo.email
                       }님, 반갑습니다!`
@@ -124,16 +124,28 @@ const Mypage = () => {
               {userInfo ? (
                 <>
                   <span className="font-14-bold color-54">이메일</span>
-                  <span className="font-14">{userInfo.email}</span>
+                  <span className="font-14">
+                    {userInfo.email ? userInfo.email : "No Data"}
+                  </span>
                   <span className="font-14-bold color-54">역할</span>
-                  <span className="font-14">{userInfo.role}</span>
+                  <span className="font-14">
+                    {userInfo.role ? userInfo.role : "No Data"}
+                  </span>
                   <span className="font-14-bold color-54">슬랙ID</span>
-                  <span className="font-14">{userInfo.slack}</span>
+                  <span className="font-14">
+                    {userInfo.slack ? userInfo.slack : "No Data"}
+                  </span>
                   <span className="font-14-bold color-54">연체</span>
-                  <span className="font-14">{`${userInfo.overDueDay}일`}</span>
+                  <span className="font-14">
+                    {userInfo.overDueDay
+                      ? `${userInfo.overDueDay}일`
+                      : "No Data"}
+                  </span>
                   <span className="font-14-bold color-54">업데이트</span>
                   <span className="font-14">
-                    {userInfo.updatedAt.slice(0, 10)}
+                    {userInfo.updatedAt
+                      ? userInfo.updatedAt.slice(0, 10)
+                      : "No Data"}
                   </span>
                 </>
               ) : null}

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -141,7 +141,13 @@ const Mypage = () => {
                       ? `${userInfo.overDueDay}일`
                       : "No Data"}
                   </span>
-                  <span className="font-14-bold color-54">업데이트</span>
+                  <span className="font-14-bold color-54">대출제한</span>
+                  <span className="font-14">
+                    {userInfo.penaltyEndDate
+                      ? `${userInfo.penaltyEndDate.slice(0, 10)} 까지`
+                      : "No Data"}
+                  </span>
+                  <span className="font-14-bold color-54">정보수정</span>
                   <span className="font-14">
                     {userInfo.updatedAt
                       ? userInfo.updatedAt.slice(0, 10)

--- a/src/component/mypage/MypageRentedBook.js
+++ b/src/component/mypage/MypageRentedBook.js
@@ -15,29 +15,55 @@ const MypageRentedBook = ({ rentInfo }) => {
           <div className="mypage-rented__book-info">
             <div className="mypage-rented__book-info-titleBox">
               <div className="mypage-rented__book-info-title font-18-bold color-2d">
-                {rentInfo[0].title.length < 22
+                {rentInfo[0].title && rentInfo[0].title.length < 22
                   ? rentInfo[0].title
-                  : rentInfo[0].title.slice(0, 22).concat("...")}
+                  : null}
+                {rentInfo[0].title && rentInfo[0].title.length >= 22
+                  ? rentInfo[0].title.slice(0, 22).concat("...")
+                  : null}
               </div>
               <div className="mypage-rented__book-info-writter font-14">
-                {rentInfo[0].author.length < 14
+                {rentInfo[0].author && rentInfo[0].author.length < 14
                   ? rentInfo[0].author
-                  : rentInfo[0].author.slice(0, 14).concat("...")}
+                  : null}
+                {rentInfo[0].author && rentInfo[0].author.length >= 14
+                  ? rentInfo[0].author.slice(0, 14).concat("...")
+                  : null}
               </div>
             </div>
             <div className="mypage-rented__book-info-rent font-14">
               <div>대출일시</div>
-              <div>{rentInfo[0].lendDate.slice(0, 10)}</div>
+              <div>
+                {rentInfo[0].lendDate
+                  ? rentInfo[0].lendDate.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>반납기한</div>
-              <div>{rentInfo[0].duedate.slice(0, 10)}</div>
+              <div>
+                {rentInfo[0].duedate
+                  ? rentInfo[0].duedate.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>연체일</div>
-              <div>{`${rentInfo[0].overDueDay}일`}</div>
+              <div>
+                {rentInfo[0].overDueDay
+                  ? `${rentInfo[0].overDueDay}일`
+                  : "No Data"}
+              </div>
               <div>비고</div>
-              <div>{rentInfo[0].lendingCondition}</div>
+              <div>
+                {rentInfo[0].lendingCondition
+                  ? rentInfo[0].lendingCondition
+                  : "No Data"}
+              </div>
             </div>
             <div className="mypage-rented__book-info-reserve font-14">
               <div>예약</div>
-              <div>{`${rentInfo[0].reservedNum}명`}</div>
+              <div>
+                {rentInfo[0].reservedNum
+                  ? `${rentInfo[0].reservedNum}명`
+                  : "No Data"}
+              </div>
             </div>
           </div>
         </div>
@@ -52,29 +78,55 @@ const MypageRentedBook = ({ rentInfo }) => {
           <div className="mypage-rented__book-info">
             <div className="mypage-rented__book-info-titleBox">
               <div className="mypage-rented__book-info-title font-18-bold color-2d">
-                {rentInfo[1].title.length < 22
+                {rentInfo[1].title && rentInfo[1].title.length < 22
                   ? rentInfo[1].title
-                  : rentInfo[1].title.slice(0, 22).concat("...")}
+                  : null}
+                {rentInfo[1].title && rentInfo[1].title.length >= 22
+                  ? rentInfo[1].title.slice(0, 22).concat("...")
+                  : null}
               </div>
               <div className="mypage-rented__book-info-writter font-14">
-                {rentInfo[1].author.length < 14
+                {rentInfo[1].author && rentInfo[1].author.length < 14
                   ? rentInfo[1].author
-                  : rentInfo[1].author.slice(0, 14).concat("...")}
+                  : null}
+                {rentInfo[1].author && rentInfo[1].author.length >= 14
+                  ? rentInfo[1].author.slice(0, 14).concat("...")
+                  : null}
               </div>
             </div>
             <div className="mypage-rented__book-info-rent font-14">
               <div>대출일시</div>
-              <div>{rentInfo[1].lendDate.slice(0, 10)}</div>
+              <div>
+                {rentInfo[1].lendDate
+                  ? rentInfo[1].lendDate.slice(0, 10)
+                  : null}
+              </div>
               <div>반납기한</div>
-              <div>{rentInfo[1].duedate.slice(0, 10)}</div>
+              <div>
+                {rentInfo[1].duedate
+                  ? rentInfo[1].duedate.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>연체일</div>
-              <div>{`${rentInfo[1].overDueDay}일`}</div>
+              <div>
+                {rentInfo[1].overDueDay
+                  ? `${rentInfo[1].overDueDay}일`
+                  : "No Data"}
+              </div>
               <div>비고</div>
-              <div>{rentInfo[1].lendingCondition}</div>
+              <div>
+                {rentInfo[1].lendingCondition
+                  ? rentInfo[1].lendingCondition
+                  : "No Data"}
+              </div>
             </div>
             <div className="mypage-rented__book-info-reserve font-14">
               <div>예약</div>
-              <div>{`${rentInfo[1].reservedNum}명`}</div>
+              <div>
+                {rentInfo[1].reservedNum
+                  ? `${rentInfo[1].reservedNum}명`
+                  : "No Data"}
+              </div>
             </div>
           </div>
         </div>

--- a/src/component/mypage/MypageReservedBook.js
+++ b/src/component/mypage/MypageReservedBook.js
@@ -34,28 +34,52 @@ const MypageReservedBook = ({ reserveInfo }) => {
           <div className="mypage-reserved__book-info">
             <div className="mypage-reserved__book-info-titleBox">
               <div className="mypage-reserved__book-info-title font-18-bold color-2d">
-                {reserveInfo[0].title.length < 22
+                {reserveInfo[0].title && reserveInfo[0].title.length < 22
                   ? reserveInfo[0].title
-                  : reserveInfo[0].title.slice(0, 22).concat("...")}{" "}
+                  : null}
+                {reserveInfo[0].title && reserveInfo[0].title.length >= 22
+                  ? reserveInfo[0].title.slice(0, 22).concat("...")
+                  : null}
               </div>
               <div className="mypage-reserved__book-info-writter font-14">
-                {reserveInfo[0].author.length < 14
+                {reserveInfo[0].author && reserveInfo[0].author.length < 14
                   ? reserveInfo[0].author
-                  : reserveInfo[0].author.slice(0, 14).concat("...")}
+                  : null}
+                {reserveInfo[0].author && reserveInfo[0].author.length >= 14
+                  ? reserveInfo[0].author.slice(0, 14).concat("...")
+                  : null}
               </div>
             </div>
             <div className="mypage-reserved__book-info-rent font-14">
               <div>예약일시</div>
-              <div>{reserveInfo[0].reservationDate.slice(0, 10)}</div>
+              <div>
+                {reserveInfo[0].reservationDate
+                  ? reserveInfo[0].reservationDate.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>예약만료</div>
-              <div>{reserveInfo[0].endAt.slice(0, 10)}</div>
+              <div>
+                {reserveInfo[0].endAt
+                  ? reserveInfo[0].endAt.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>예약순위</div>
-              <div>{`${reserveInfo[0].ranking}위`}</div>
+              <div>
+                {reserveInfo[0].ranking
+                  ? `${reserveInfo[0].ranking}위`
+                  : "No Data"}
+              </div>
             </div>
             <button
               className="mypage-reserved__book-cancle_reserve font-14"
               type="button"
-              onClick={() => onClickCancle(reserveInfo[0].reservationId)}
+              onClick={() =>
+                onClickCancle(
+                  reserveInfo[0].reservationId
+                    ? reserveInfo[0].reservationId
+                    : null,
+                )
+              }
             >
               예약 취소
             </button>
@@ -72,28 +96,52 @@ const MypageReservedBook = ({ reserveInfo }) => {
           <div className="mypage-reserved__book-info">
             <div className="mypage-reserved__book-info-titleBox">
               <div className="mypage-reserved__book-info-title font-18-bold color-2d">
-                {reserveInfo[1].title.length < 22
+                {reserveInfo[1].title && reserveInfo[1].title.length < 22
                   ? reserveInfo[1].title
-                  : reserveInfo[1].title.slice(0, 22).concat("...")}{" "}
+                  : null}
+                {reserveInfo[1].title && reserveInfo[1].title.length >= 22
+                  ? reserveInfo[1].title.slice(0, 22).concat("...")
+                  : null}
               </div>
               <div className="mypage-reserved__book-info-writter font-14">
-                {reserveInfo[1].author.length < 14
+                {reserveInfo[1].author && reserveInfo[1].author.length < 14
                   ? reserveInfo[1].author
-                  : reserveInfo[1].author.slice(0, 14).concat("...")}
+                  : null}
+                {reserveInfo[1].author && reserveInfo[1].author.length >= 14
+                  ? reserveInfo[1].author.slice(0, 14).concat("...")
+                  : null}
               </div>
             </div>
             <div className="mypage-reserved__book-info-rent font-14">
               <div>예약일시</div>
-              <div>{reserveInfo[1].reservationDate.slice(0, 10)}</div>
+              <div>
+                {reserveInfo[1].reservationDate
+                  ? reserveInfo[1].reservationDate.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>예약만료</div>
-              <div>{reserveInfo[1].endAt.slice(0, 10)}</div>
+              <div>
+                {reserveInfo[1].endAt
+                  ? reserveInfo[1].endAt.slice(0, 10)
+                  : "No Data"}
+              </div>
               <div>예약순위</div>
-              <div>{`${reserveInfo[1].ranking}위`}</div>
+              <div>
+                {reserveInfo[1].ranking
+                  ? `${reserveInfo[1].ranking}위`
+                  : "No Data"}
+              </div>
             </div>
             <button
               className="mypage-reserved__book-cancle_reserve font-14"
               type="button"
-              onClick={() => onClickCancle(reserveInfo[1].reservationId)}
+              onClick={() =>
+                onClickCancle(
+                  reserveInfo[1].reservationId
+                    ? reserveInfo[1].reservationId
+                    : null,
+                )
+              }
             >
               예약 취소
             </button>

--- a/src/component/reservedloan/ReservedFilter.js
+++ b/src/component/reservedloan/ReservedFilter.js
@@ -45,7 +45,7 @@ const ReservedFilter = ({
               isPending ? "color-red" : "color-a4"
             }`}
           >
-            대출 대기 중
+            예약 0순위
           </span>
         </button>
         <button
@@ -63,7 +63,7 @@ const ReservedFilter = ({
               isWaiting ? "color-red" : "color-a4"
             }`}
           >
-            예약 배정 대기 중
+            예약 후순위
           </span>
         </button>
         <button

--- a/src/component/reservedloan/ReservedLoan.js
+++ b/src/component/reservedloan/ReservedLoan.js
@@ -72,6 +72,7 @@ const ReservedLoan = () => {
     userSearchWord,
     resevedLoanPage,
     isPending,
+    isWaiting,
     isExpired,
   ]);
 
@@ -123,6 +124,7 @@ const ReservedLoan = () => {
               key={factor.id}
               isPending={isPending}
               isWaiting={isWaiting}
+              isExpired={isExpired}
               factor={factor}
               openModal={openModal}
               setInfo={setReservedInfo}

--- a/src/component/reservedloan/ReservedModalContents.js
+++ b/src/component/reservedloan/ReservedModalContents.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/forbid-prop-types */
 import React, { useState } from "react";
 import PropTypes from "prop-types";
 import axios from "axios";
@@ -114,7 +113,7 @@ const ReservedModalContents = ({
               대출 완료하기
             </button>
             <button
-              className="modal__button mid font-20 color-ff"
+              className="modal__button mid font-20 color-ff confirm"
               type="button"
               onClick={deleteReservation}
             >
@@ -128,7 +127,7 @@ const ReservedModalContents = ({
 };
 
 ReservedModalContents.propTypes = {
-  reservedInfo: PropTypes.object.isRequired,
+  reservedInfo: PropTypes.shape.isRequired,
   setMiniModalContents: PropTypes.func.isRequired,
   setLendResult: PropTypes.func.isRequired,
 };

--- a/src/component/reservedloan/ReservedTableList.js
+++ b/src/component/reservedloan/ReservedTableList.js
@@ -6,6 +6,7 @@ import Arr from "../../img/arrow_right_black.svg";
 const ReservedTableList = ({
   isPending,
   isWaiting,
+  isExpired,
   factor,
   openModal,
   setInfo,
@@ -13,6 +14,12 @@ const ReservedTableList = ({
   const openSetModal = () => {
     setInfo(factor);
     openModal();
+  };
+
+  const printEndReason = status => {
+    if (status === 1) return "대출 완료";
+    if (status === 2) return "예약 취소";
+    return "예약 기한 만료";
   };
 
   // console.log(factor && factor.endAt && factor.endAt.slice(0, 10));
@@ -47,6 +54,9 @@ const ReservedTableList = ({
               : null}
             {factor && factor.createdAt && isWaiting
               ? `예약 시작일 : ${factor.createdAt.slice(0, 10)}`
+              : null}
+            {factor && factor.status && isExpired
+              ? `예약 만료 이유 : ${printEndReason(factor.status)}`
               : null}
           </span>
         </div>

--- a/src/component/reservedloan/ReservedTableList.js
+++ b/src/component/reservedloan/ReservedTableList.js
@@ -1,5 +1,5 @@
-/* eslint-disable react/prop-types */
 import React from "react";
+import PropTypes from "prop-types";
 import "../../css/ReservedTableList.css";
 import Arr from "../../img/arrow_right_black.svg";
 
@@ -21,8 +21,6 @@ const ReservedTableList = ({
     if (status === 2) return "예약 취소";
     return "예약 기한 만료";
   };
-
-  // console.log(factor && factor.endAt && factor.endAt.slice(0, 10));
 
   return (
     <div className="reserved-loan__table-list">
@@ -63,6 +61,15 @@ const ReservedTableList = ({
       </button>
     </div>
   );
+};
+
+ReservedTableList.propTypes = {
+  isPending: PropTypes.bool.isRequired,
+  isWaiting: PropTypes.bool.isRequired,
+  isExpired: PropTypes.bool.isRequired,
+  factor: PropTypes.shape.isRequired,
+  openModal: PropTypes.func.isRequired,
+  setInfo: PropTypes.func.isRequired,
 };
 
 export default ReservedTableList;

--- a/src/component/utils/HeaderModal.js
+++ b/src/component/utils/HeaderModal.js
@@ -123,7 +123,7 @@ const HeaderModal = ({ setHeaderModal }) => {
             {user.id ? (
               <Link
                 className="header-modal__button"
-                to={{ pathname: `/return` }}
+                to={{ pathname: `/mypage` }}
               >
                 <img src={Mypage} className="header-modal__icon" alt="user" />
                 <span className="header-modal__text font-16 color-2d">

--- a/src/css/EditEmail.css
+++ b/src/css/EditEmail.css
@@ -67,3 +67,13 @@
   cursor: pointer;
   transform: scale(1.1);
 }
+
+@media screen and (max-width: 420px) {
+  .mypage-edit-emailBox {
+    width: 100%;
+  }
+  .mypage-edit-email-title {
+    width: 100%;
+    white-space: break-spaces;
+  }
+}

--- a/src/css/EditPassword.css
+++ b/src/css/EditPassword.css
@@ -1,11 +1,13 @@
 .mypage-edit-pw {
   height: 60rem;
-  max-width: 95rem;
+  max-width: 40rem;
+  margin: 0 auto;
   display: flex;
   justify-content: center;
 }
 
 .mypage-edit-pwBox {
+  width: 100%;
   margin-top: 10rem;
 }
 
@@ -24,9 +26,15 @@
 }
 
 .mypage-edit-pw-title {
-  font-size: 22px;
-  font-weight: bold;
   margin-bottom: 4.5rem;
+}
+
+.margin-bottom-2rem {
+  margin-bottom: 2rem;
+}
+
+.inline-block {
+  display: inline-block;
 }
 
 .mypage-edit-pw-new_pw {
@@ -61,7 +69,8 @@
 
 .mypage-edit-pw-button {
   display: flex;
-  justify-content: flex-end;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .mypage-edit-pw-button button {
@@ -74,4 +83,22 @@
 .mypage-edit-pw-button button:hover {
   cursor: pointer;
   transform: scale(1.1);
+}
+
+@media screen and (max-width: 420px) {
+  .mypage-edit-pw {
+    width: 100%;
+  }
+  .mypage-edit-pw-title {
+    width: 100%;
+    white-space: break-spaces;
+  }
+  .mypage-edit-pw-new_pw {
+    grid-template-columns: 30% 60%;
+    column-gap: 2rem;
+  }
+  .mypage-edit-pw-check_pw {
+    grid-template-columns: 30% 60%;
+    column-gap: 2rem;
+  }
 }

--- a/src/css/Mypage.css
+++ b/src/css/Mypage.css
@@ -51,6 +51,7 @@
 
 .mypage-inquire-box-short-wrapper {
   min-width: 40rem;
+  margin-left: 3rem;
 }
 
 .mypage-inquire-box-short-wrapper .inquire-box-title {
@@ -59,7 +60,6 @@
 
 .mypage-inquire-box-short-wrapper .inquire-box-title__icon {
   height: 3rem;
-  margin-left: 4rem;
 }
 
 .mypage-inquire-box-short {
@@ -132,12 +132,20 @@
     height: unset;
     margin-bottom: 0;
   }
+  .mypage-inquire-box-long-wrapper .inquire-box-title {
+    height: 6rem;
+  }
+  .mypage-inquire-box-long-wrapper .inquire-box-title__icon {
+    height: unset;
+    width: 2.8rem;
+  }
   .mypage-inquire-box-short-clickBox {
     margin-top: 2rem;
   }
   .mypage-inquire-box-short-wrapper {
     min-width: unset;
     width: 100%;
+    margin-left: unset;
   }
   .mypage-subtitle__titlebox__guide__2 {
     white-space: break-spaces;

--- a/src/css/Mypage.css
+++ b/src/css/Mypage.css
@@ -1,5 +1,5 @@
 .mypage-subtitle {
-  padding: 11rem 0 2rem 0;
+  padding: 11rem 0 3rem 0;
 }
 
 .mypage-qna {

--- a/src/css/MypageRoutes.css
+++ b/src/css/MypageRoutes.css
@@ -1,4 +1,5 @@
 .mypage-wrapper {
+  min-width: 360px;
   padding: 0 15rem 0 15rem;
 }
 

--- a/src/css/ReservedLoan.css
+++ b/src/css/ReservedLoan.css
@@ -1,3 +1,7 @@
+.reserved-loan-body {
+  min-width: 360px;
+}
+
 .reserved-loan-main {
   margin: 0 auto;
 }

--- a/src/css/reset.css
+++ b/src/css/reset.css
@@ -199,6 +199,11 @@ body {
   font-weight: bold;
 }
 
+.font-22-bold {
+  font-size: 2.2rem;
+  font-weight: bold;
+}
+
 .font-20-bold {
   font-size: 2rem;
   font-weight: bold;


### PR DESCRIPTION
## 1. 해결사항

### 1) 마이페이지 변경사항
1. 비밀번호 network-payload 에서 안 보이는 방법이 없을까요? ► 멘토링 해야할 듯!
2. 비밀번호 조건이 보이도록 추가합니다.
3. 모바일에서 인콰이어 박스를 줄입니다.
4. width 가 780px인 임계값을 고려합니다.
5. min-width 360px 추가
6. 마이페이지 이메일 및 패스워드 모바일 반응형 

### 2) 예약대출 변경사항

1. 왜 예약이 종료가 되었는지 적어주어야 합니다.
2. 예약 취소를 기본적으로 빨간색으로 만들어줍니다.
3. wrapper에 min-width 360px 을 추가합니다.

### 3) 이외의 변경사항

- 마이페이지 patch 요청에서 params를 빼서 보내줍니다.
- 예약페이지 prop이 없었던 것들을 추가했습니다.
- 모바일 헤더에 마이페이지 연결했습니다.

## 2. 해결 스크린샷

### 1) 마이페이지 관련

<p>
<img src="https://user-images.githubusercontent.com/79993356/175781170-f7a0ae14-dd43-46cd-9b57-eef3286e1288.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175781176-7645f437-1ffd-4614-9303-3bf357a0fe47.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175781189-28f35021-8c47-49ab-a020-f9a32d1647f5.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175781204-a61e947c-43d1-43bd-a2d6-9cd5e9207d6a.png" width="350" />
</p>

### 2) 예약 대출 관련

예약 만료 이유에 대해서는 

- status 1 : 대출완료
- status 2 : 예약 취소
- status 3 : 예약 기한 만료

입니다!

<p>
<img src="https://user-images.githubusercontent.com/79993356/175780955-4bb19118-c915-418c-aaf5-45fa9a7370fa.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175780960-5bdf0dff-6afe-4c4f-9b77-1d21a3859593.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175781054-5b726199-330b-4721-824c-28c1df5941c9.png" width="350" />
<img src="https://user-images.githubusercontent.com/79993356/175781069-e9d586a7-c142-4544-8d6e-b6ad90be246e.png" width="350" />
</p>
