### PR TITLE
Jip 234 category filter 의 next 및 pre 버튼 작동 fix

### DIFF
--- a/src/component/search/CategoryFilter.js
+++ b/src/component/search/CategoryFilter.js
@@ -8,6 +8,7 @@ import ArrRightBlack from "../../img/arrow_right_black.svg";
 import "../../css/CategoryFilter.css";
 
 const MARGIN_OF_CATEGORY_BUTTON = 36;
+const EPSILON = 1;
 
 const PreCategory = ({ startOfScroll }) => {
   const scrollToPre = () => {
@@ -22,7 +23,10 @@ const PreCategory = ({ startOfScroll }) => {
     let sumOfCategory = 0;
     // eslint-disable-next-line no-plusplus
     for (let index = 0; index < categoryButtonWidth.length; index++) {
-      if (sumOfCategory + categoryButtonWidth[index] >= categoriesScrollX) {
+      if (
+        sumOfCategory + categoryButtonWidth[index] + EPSILON >=
+        categoriesScrollX
+      ) {
         break;
       }
       sumOfCategory += categoryButtonWidth[index];
@@ -68,7 +72,7 @@ const NextCategory = ({ endOfScroll }) => {
     // eslint-disable-next-line no-plusplus
     for (let index = 0; index < categoryButtonWidth.length; index++) {
       sumOfCategory += categoryButtonWidth[index];
-      if (sumOfCategory > categoriesScrollX) {
+      if (sumOfCategory - EPSILON > categoriesScrollX) {
         break;
       }
     }

--- a/src/component/search/Search.js
+++ b/src/component/search/Search.js
@@ -55,6 +55,8 @@ const Search = ({ match, location }) => {
         setLastPage(
           res.data.meta.totalPages > 0 ? res.data.meta.totalPages : 1,
         );
+        setMiniModal(0);
+        setErrorCode(-1);
       })
       .catch(error => {
         setMiniModal(1);


### PR DESCRIPTION
### 1. category filter 의 next 및 pre 버튼 작동 fix
- 카테고리 필터의 Next Category 버튼과 Pre Category 버튼이 제대로 작동하지 않아 수정했습니다
- 원인은 `categoriesScrollX` 가 소수점이 될때가 있어서 조건문이 의도대로 작동하지 않은 탓이었습니다.
- 보정값(EPSILON)을 추가하여 해결했습니다.

<br>

### 2. bookinfo search api 호출 성공시 errorCode 초기화
- errorCode와 MiniModal을 초기화하여 에러상황과 구분했습니다