### PR TITLE
Jip 239 마이페이지 버그 수정

### DIFF
--- a/src/component/mypage/EditEmail.js
+++ b/src/component/mypage/EditEmail.js
@@ -10,6 +10,7 @@ function EditEmail() {
   const history = useHistory();
   const [isMiniModalOpen, setIsMiniModalOpen] = useState(false);
   const [miniModalContent, setMiniModalContent] = useState("");
+  const [isGoBack, setIsGoBack] = useState(false);
   const [userInfo, setUserInfo] = useState(null);
   const [newEmail, setNewEmail] = useState("");
 
@@ -28,14 +29,19 @@ function EditEmail() {
         email: newEmail,
       })
       .then(() => {
-        history.goBack();
         setMiniModalContent("이메일 변경 성공");
         setIsMiniModalOpen(true);
+        setIsGoBack(true);
       })
       .catch(err => {
         setMiniModalContent(err.message);
         setIsMiniModalOpen(true);
       });
+  };
+
+  const closeModal = () => {
+    setIsMiniModalOpen(false);
+    if (isGoBack) history.goBack();
   };
 
   useEffect(async () => {
@@ -68,34 +74,38 @@ function EditEmail() {
         </div>
         <div className="mypage-edit-email-curr_email">
           <span className="font-14-bold color-2d">현재 이메일</span>
-          <span className="font-14">{userInfo ? userInfo.email : "-"}</span>
+          <span className="font-14 text-center">
+            {userInfo ? userInfo.email : "-"}
+          </span>
         </div>
         <form onSubmit={onSubmitUpdate}>
-          <div className="mypage-edit-email-new_email">
+          <div className="mypage-edit-email-new_email font-14">
             <span className="font-14-bold color-2d">새로운 이메일</span>
             <input
               value={newEmail}
               type="email"
               onChange={onChangeInput}
               placeholder="이메일을 입력해주세요"
-              // eslint-disable-next-line no-return-assign
-              onFocus={e => (e.target.placeholder = "")}
-              // eslint-disable-next-line no-return-assign
-              onBlur={e => (e.target.placeholder = "이메일을 입력해주세요")}
+              onFocus={e => {
+                e.target.placeholder = "";
+              }}
+              onBlur={e => {
+                e.target.placeholder = "이메일을 입력해주세요";
+              }}
             />
           </div>
           <div className="mypage-edit-email-button">
-            <button className="font-14 " type="submit">
+            <button className="font-14" type="submit">
               변경
             </button>
           </div>
         </form>
       </div>
       {isMiniModalOpen ? (
-        <MiniModal closeModal={() => setIsMiniModalOpen(false)}>
+        <MiniModal closeModal={closeModal}>
           <ModalContentsOnlyTitle
             title={miniModalContent}
-            closeModal={() => setIsMiniModalOpen(false)}
+            closeModal={closeModal}
           />
         </MiniModal>
       ) : null}

--- a/src/component/mypage/EditEmail.js
+++ b/src/component/mypage/EditEmail.js
@@ -42,7 +42,8 @@ function EditEmail() {
     await axios
       .get(`${process.env.REACT_APP_API}/users/search`, {
         params: {
-          nickname: JSON.parse(window.localStorage.getItem("user")).userId,
+          nicknameOrEmail: JSON.parse(window.localStorage.getItem("user"))
+            .userId,
         },
       })
       .then(res => setUserInfo(res.data.items[0]))

--- a/src/component/mypage/EditPassword.js
+++ b/src/component/mypage/EditPassword.js
@@ -10,8 +10,13 @@ function EditPassword() {
   const history = useHistory();
   const [isMiniModalOpen, setIsMiniModalOpen] = useState(false);
   const [miniModalContent, setMiniModalContent] = useState("");
+  const [isGoBack, setIsGoBack] = useState(false);
   const [newPw, setNewPw] = useState("");
   const [checkPw, setCheckPw] = useState("");
+
+  const onClickLeftArrow = () => {
+    history.goBack();
+  };
 
   const onChangeNewPw = e => {
     setNewPw(e.target.value);
@@ -33,9 +38,9 @@ function EditPassword() {
         password: newPw,
       })
       .then(() => {
-        history.goBack();
-        setMiniModalContent("비밀번호 변경에 성공");
+        setMiniModalContent("비밀번호 변경 성공");
         setIsMiniModalOpen(true);
+        setIsGoBack(true);
       })
       .catch(err => {
         setMiniModalContent(err.message);
@@ -43,8 +48,9 @@ function EditPassword() {
       });
   };
 
-  const onClickLeftArrow = () => {
-    history.goBack();
+  const closeModal = () => {
+    setIsMiniModalOpen(false);
+    if (isGoBack) history.goBack();
   };
 
   return (
@@ -68,12 +74,15 @@ function EditPassword() {
         <div className="mypage-edit-pw-new_pw">
           <span className="font-14-bold">새로운 비밀번호</span>
           <input
+            className="font-14"
             placeholder="비밀번호 입력"
             type="password"
-            // eslint-disable-next-line no-return-assign
-            onFocus={e => (e.target.placeholder = "")}
-            // eslint-disable-next-line no-return-assign
-            onBlur={e => (e.target.placeholder = "비밀번호 입력")}
+            onFocus={e => {
+              e.target.placeholder = "";
+            }}
+            onBlur={e => {
+              e.target.placeholder = "비밀번호 입력";
+            }}
             onChange={onChangeNewPw}
           />{" "}
         </div>
@@ -81,12 +90,15 @@ function EditPassword() {
           <div className="mypage-edit-pw-check_pw">
             <span className="font-14-bold">비밀번호 재입력</span>
             <input
+              className="font-14"
               placeholder="비밀번호 재입력"
               type="password"
-              // eslint-disable-next-line no-return-assign
-              onFocus={e => (e.target.placeholder = "")}
-              // eslint-disable-next-line no-return-assign
-              onBlur={e => (e.target.placeholder = "비밀번호 재입력")}
+              onFocus={e => {
+                e.target.placeholder = "";
+              }}
+              onBlur={e => {
+                e.target.placeholder = "비밀번호 재입력";
+              }}
               onChange={onChangeCheckPw}
             />
           </div>
@@ -101,10 +113,10 @@ function EditPassword() {
         </form>
       </div>
       {isMiniModalOpen ? (
-        <MiniModal closeModal={() => setIsMiniModalOpen(false)}>
+        <MiniModal closeModal={closeModal}>
           <ModalContentsOnlyTitle
             title={miniModalContent}
-            closeModal={() => setIsMiniModalOpen(false)}
+            closeModal={closeModal}
           />
         </MiniModal>
       ) : null}

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -26,7 +26,7 @@ const Mypage = () => {
   });
   const [queryErrorCode, setQueryErrorCode] = useState(query.errorCode);
 
-  useEffect(async () => {
+  const getUserInfo = async () => {
     await axios
       .get(`${process.env.REACT_APP_API}/users/search`, {
         params: {
@@ -56,6 +56,19 @@ const Mypage = () => {
         setMiniModalContent(err.message);
         setIsMiniModalOpen(true);
       });
+  };
+
+  const closeModal = async () => {
+    if (isMiniModalOpen) {
+      await getUserInfo();
+      setIsMiniModalOpen(false);
+    } else if (queryErrorCode) {
+      setQueryErrorCode(null);
+    }
+  };
+
+  useEffect(async () => {
+    await getUserInfo();
   }, []);
 
   useEffect(() => {
@@ -190,21 +203,23 @@ const Mypage = () => {
         <div className="mypage-inquire-box-long">
           <MypageReservedBook
             reserveInfo={userInfo ? userInfo.reservations : null}
+            setIsMiniModalOpen={setIsMiniModalOpen}
+            setMiniModalContent={setMiniModalContent}
           />
         </div>
       </div>
       {isMiniModalOpen ? (
-        <MiniModal closeModal={() => setIsMiniModalOpen(false)}>
+        <MiniModal closeModal={closeModal}>
           <ModalContentsOnlyTitle
-            closeModal={() => setIsMiniModalOpen(false)}
+            closeModal={closeModal}
             title={miniModalContent}
           />
         </MiniModal>
       ) : null}
       {queryErrorCode && (
-        <MiniModal closeModal={() => setQueryErrorCode(null)}>
+        <MiniModal closeModal={closeModal}>
           <ModalContentsTitleWithMessage
-            closeModal={() => setQueryErrorCode(null)}
+            closeModal={closeModal}
             title={
               getErrorMessage("mypage", parseInt(queryErrorCode, 10)).title
             }

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -33,25 +33,7 @@ const Mypage = () => {
           id: JSON.parse(window.localStorage.getItem("user")).id,
         },
       })
-      .then(res =>
-        setUserInfo(() => {
-          const rtnObj = Object.assign(res.data.items[0]);
-          switch (rtnObj.role) {
-            case 1:
-              rtnObj.role = "카뎃";
-              break;
-            case 2:
-              rtnObj.role = "사서";
-              break;
-            case 3:
-              rtnObj.role = "운영진";
-              break;
-            default:
-              rtnObj.role = "미인증";
-          }
-          return rtnObj;
-        }),
-      )
+      .then(res => setUserInfo(res.data.items[0]))
       .catch(err => {
         setMiniModalContent(err.message);
         setIsMiniModalOpen(true);
@@ -64,6 +46,19 @@ const Mypage = () => {
       setIsMiniModalOpen(false);
     } else if (queryErrorCode) {
       setQueryErrorCode(null);
+    }
+  };
+
+  const convertRoleToStr = roleInt => {
+    switch (roleInt) {
+      case 1:
+        return "카뎃";
+      case 2:
+        return "사서";
+      case 3:
+        return "운영진";
+      default:
+        return "미인증";
     }
   };
 
@@ -150,7 +145,9 @@ const Mypage = () => {
                   </span>
                   <span className="font-14-bold color-54">역할</span>
                   <span className="font-14">
-                    {userInfo.role ? userInfo.role : "No Data"}
+                    {userInfo.role
+                      ? convertRoleToStr(userInfo.role)
+                      : "No Data"}
                   </span>
                   <span className="font-14-bold color-54">슬랙ID</span>
                   <span className="font-14">

--- a/src/component/mypage/MypageRentedBook.js
+++ b/src/component/mypage/MypageRentedBook.js
@@ -136,8 +136,7 @@ const MypageRentedBook = ({ rentInfo }) => {
 };
 
 MypageRentedBook.propTypes = {
-  // eslint-disable-next-line react/require-default-props
-  rentInfo: PropTypes.arrayOf(PropTypes.object.isRequired),
+  rentInfo: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
 };
 
 export default MypageRentedBook;

--- a/src/component/mypage/MypageReservedBook.js
+++ b/src/component/mypage/MypageReservedBook.js
@@ -1,14 +1,13 @@
-import React, { useState } from "react";
+import React from "react";
 import "../../css/MypageReservedBook.css";
 import axios from "axios";
 import PropTypes from "prop-types";
-import MiniModal from "../utils/MiniModal";
-import ModalContentsOnlyTitle from "../utils/ModalContentsOnlyTitle";
 
-const MypageReservedBook = ({ reserveInfo }) => {
-  const [isMiniModalOpen, setIsMiniModalOpen] = useState(false);
-  const [miniModalContent, setMiniModalContent] = useState("");
-
+const MypageReservedBook = ({
+  reserveInfo,
+  setIsMiniModalOpen,
+  setMiniModalContent,
+}) => {
   const onClickCancle = async id => {
     await axios
       .patch(`${process.env.REACT_APP_API}/reservations/cancel/${id}`)
@@ -148,21 +147,14 @@ const MypageReservedBook = ({ reserveInfo }) => {
           </div>
         </div>
       ) : null}
-      {isMiniModalOpen ? (
-        <MiniModal closeModal={() => setIsMiniModalOpen(false)}>
-          <ModalContentsOnlyTitle
-            title={miniModalContent}
-            closeModal={() => setIsMiniModalOpen(false)}
-          />
-        </MiniModal>
-      ) : null}
     </div>
   );
 };
 
 MypageReservedBook.propTypes = {
-  // eslint-disable-next-line react/require-default-props
-  reserveInfo: PropTypes.arrayOf(PropTypes.object.isRequired),
+  reserveInfo: PropTypes.arrayOf(PropTypes.object.isRequired).isRequired,
+  setIsMiniModalOpen: PropTypes.func.isRequired,
+  setMiniModalContent: PropTypes.func.isRequired,
 };
 
 export default MypageReservedBook;

--- a/src/css/EditEmail.css
+++ b/src/css/EditEmail.css
@@ -36,6 +36,10 @@
   margin-bottom: 3.5rem;
 }
 
+.text-center {
+  text-align: center;
+}
+
 .mypage-edit-email-new_email {
   width: 100%;
   display: grid;


### PR DESCRIPTION
## 🐞 버그 1
<img src="https://user-images.githubusercontent.com/79993356/176230788-1a8ebbc2-d4c0-4103-a83b-35772f5d6f1d.gif" width="500" />
이메일 변경 페이지에서 자신의 것이 아닌 이상한 것이 들어있는 오류가 발생했습니다.

## 🙋 해결
nickname을 nicknameOrEmail로 변경하지 않아서 생긴 오류였으며 이를 수정했습니다.

## 🐞 버그 2
<img width="500" alt="image" src="https://user-images.githubusercontent.com/79993356/176231058-1c0d299f-04a1-4f5c-b44a-c253bf0d1b8e.png">
예약 취소 완료를 나타내는 모달과, 박스의 타이틀의 전후관계가 이상합니다.

## 🙋 해결
1) 기존 예약정보 타이틀과 예약 취소의 전후 관계가 이상한 것을 해결했습니다. 
기존에는 Reserve에서 따로 모달을 썼기 때문에, 해당 모달이 예약정보 타이틀보다 하위 컴포넌트이기 때문에 z-index가 먹히지 않는 오류였습니다. 따라서 하위 컴포넌트의 모달을 지우고, 상위 컴포넌트에서 상태값을 상속해주면서 이를 해결했습니다.

<img width="500" alt="image" src="https://user-images.githubusercontent.com/79993356/176231325-9d96b2eb-6f3a-41d4-90b9-85e93e33b419.png">

2) 얘약 취소를 하면, 자동으로 전체 마이페이지 정보를 다시 불러오도록  했습니다. 
get 부분을 따로 함수로 만들어 해당 함수가 모달이 닫힐 때에 실행됩니다.

3) 이메일 변경 페이지에서, 이메일을 전부 중앙정렬로 만들었습니다.

4) 이메일과 패스워드를 변경하면 모달이 안 뜨고 바로 이전 페이지로 넘어갑니다.
이는 모달이 뜨기 전에 `history.goback`을 해서 그렇습니다. 이를 모달을 닫아야만 실행되도록 교체했습니다.

5) `eslint` 오류를 임시로 주석처리한 것들을 이제 모두 교체합니다.
