### PR TITLE
JIP-246 FIX: 마이페이지 에러 모달을 닫을 때에 쿼리 삭제

### DIFF
--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link, useLocation, useHistory } from "react-router-dom";
 import axios from "axios";
 import "../../css/Mypage.css";
 import qs from "qs";
@@ -16,6 +16,7 @@ import ModalContentsTitleWithMessage from "../utils/ModalContentsTitleWithMessag
 import getErrorMessage from "../utils/error";
 
 const Mypage = () => {
+  const history = useHistory();
   const [userInfo, setUserInfo] = useState(null);
   const [isMiniModalOpen, setIsMiniModalOpen] = useState(false);
   const [miniModalContent, setMiniModalContent] = useState("");
@@ -46,6 +47,7 @@ const Mypage = () => {
       setIsMiniModalOpen(false);
     } else if (queryErrorCode) {
       setQueryErrorCode(null);
+      history.push("/mypage");
     }
   };
 
@@ -78,6 +80,8 @@ const Mypage = () => {
       window.removeEventListener("resize", getWindowWidth);
     };
   }, []);
+
+  console.log(query.errorCode);
 
   return (
     <>


### PR DESCRIPTION
기존에는 query.errorCode 를 통해 상태값을 설정하고 있었습니다.
그런데 모달을 닫더라도 쿼리 스트링이 삭제되지 않았습니다.
따라서 useHistory를 사용해 쿼리 스트링을 삭제합니다.