### PR TITLE
Jip 270 debug 유저 정보 초기화 처리

### DIFF
--- a/src/component/userManagement/UserDetailInfo.js
+++ b/src/component/userManagement/UserDetailInfo.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import "../../css/UserBriefInfo.css";
 import "../../css/UserDetailInfo.css";
 
-const roles = ["미인증", "일반", "사서", "스태프"];
+const roles = ["미인증", "카뎃", "사서", "운영진"];
 
 const UserInfoEdit = ({ infoKey, infoId, infoType, infoValue }) => {
   const [input, setInput] = useState(infoValue);
@@ -59,19 +59,16 @@ const UserInfoDisplay = ({ infoKey, infoValue }) => {
 };
 
 const convertDatetoString = date => {
-  let overDueDate = "";
+  let stringDate = "";
 
-  console.log(typeof date);
-  console.log(date);
-
-  overDueDate += date.getFullYear();
-  overDueDate += "-";
-  overDueDate += date.getMonth() + 1 < 10 ? "0" : "";
-  overDueDate += date.getMonth() + 1;
-  overDueDate += "-";
-  overDueDate += date.getDate() < 10 ? "0" : "";
-  overDueDate += date.getDate();
-  return overDueDate;
+  stringDate += date.getFullYear();
+  stringDate += "-";
+  stringDate += date.getMonth() + 1 < 10 ? "0" : "";
+  stringDate += date.getMonth() + 1;
+  stringDate += "-";
+  stringDate += date.getDate() < 10 ? "0" : "";
+  stringDate += date.getDate();
+  return stringDate;
 };
 
 const UserDetailInfo = ({
@@ -171,9 +168,8 @@ const UserDetailInfo = ({
             infoId="penalty"
             infoType="date"
             infoValue={
-              userPenalty &&
-              userPenalty.substring(0, 10) >= convertDatetoString(today)
-                ? userPenalty.substring(0, 10)
+              userPenalty && userPenalty >= convertDatetoString(today)
+                ? userPenalty
                 : convertDatetoString(today)
             }
           />
@@ -214,9 +210,8 @@ const UserDetailInfo = ({
           <UserInfoDisplay
             infoKey="대출 불가 기간"
             infoValue={
-              userPenalty &&
-              userPenalty.substring(0, 10) >= convertDatetoString(today)
-                ? userPenalty.substring(0, 10)
+              userPenalty && userPenalty >= convertDatetoString(today)
+                ? userPenalty
                 : "-"
             }
           />

--- a/src/component/userManagement/UserDetailInfo.js
+++ b/src/component/userManagement/UserDetailInfo.js
@@ -101,14 +101,11 @@ const UserDetailInfo = ({
       .patch(`${process.env.REACT_APP_API}/users/update/${user.id}`, data)
       .then(res => {
         const userInfo = res.data;
-        if (userInfo.intraId) setUserIntraId(userInfo.intraId);
-        if (userInfo.nickname) setUserNickname(userInfo.nickname);
-        if (userInfo.slack) setUserSlack(userInfo.slack);
-        if (userInfo.role) setUserRoleNum(userInfo.role);
-        if (userInfo.penaltyEndDate) {
-          const penaltyEndDate = new Date(userInfo.penaltyEndDate);
-          setUserPenalty(convertDatetoString(penaltyEndDate));
-        }
+        setUserIntraId(userInfo.intraId);
+        setUserNickname(userInfo.nickname);
+        setUserSlack(userInfo.slack);
+        setUserRoleNum(userInfo.role);
+        setUserPenalty(userInfo.penaltyEndDate);
       })
       .catch(error => {
         closeMidModal();
@@ -122,15 +119,18 @@ const UserDetailInfo = ({
     const userEditForm = document.getElementById("edit-form");
     const intra = userEditForm.querySelector(".edit-intra-id").value;
     const nickname = userEditForm.querySelector(".edit-nickname").value;
-    const role = userEditForm.querySelector(".edit-role").value;
+    const roleNum = userEditForm.querySelector(".edit-role").value;
     const slack = userEditForm.querySelector(".edit-slack").value;
     const penalty = userEditForm.querySelector(".edit-penalty").value;
 
+    const intraId = parseInt(intra, 10);
+    const role = parseInt(roleNum, 10);
+
     const data = {
-      nickname,
-      intraId: parseInt(intra, 10),
-      slack,
-      role: parseInt(role, 10),
+      nickname: nickname === "" ? null : nickname,
+      intraId: Number.isNaN(intraId) ? null : intraId,
+      slack: slack === "" ? null : slack,
+      role: Number.isNaN(role) ? 0 : role,
       penaltyEndDate: penalty,
     };
     patchUserInfo(data);


### PR DESCRIPTION
유저정보를 수정할 때 빈칸으로 둔 채 저장하면 null 값으로 업데이트 되도록했습니다.
다만 인트라 id, 인트라 닉네임, 슬랙 id 일부만 null 상황이 괜찮을지는 좀 더 고민해봐야할 것 같습니다..!
그리고 다른 항목은 null로 업데이트가 되는데 인트라 id는 null을 보내면 백엔드 쪽에서 먹히지 않고 있는거 같네요.

https://user-images.githubusercontent.com/74581396/177002488-618106f3-ab68-40ff-ad51-508a8b2e09fb.mov

![스크린샷 2022-07-02 오후 9 59 07](https://user-images.githubusercontent.com/74581396/177002502-c5d4a392-c39e-4bb2-b870-7e1d5e4b54e7.png)
![스크린샷 2022-07-02 오후 9 59 23](https://user-images.githubusercontent.com/74581396/177002504-2f56cef9-fe6b-4b8a-887a-33a4dafa1c4c.png)


