### PR TITLE
JIP-282 FIX: 빌드시 gnb__user__button css 적용안되는 문제 해결

### DIFF
--- a/src/css/Header.css
+++ b/src/css/Header.css
@@ -75,6 +75,12 @@ a:active {
   word-break: keep-all;
 }
 
+.gnb__user__text {
+  max-width: 10rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .gnb__icon {
   margin: 0 1rem 0 0;
   object-fit: contain;
@@ -90,13 +96,6 @@ a:active {
   height: 2.2rem;
 }
 
-.gnb__button {
-  margin: 0 0 0 5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .gnb__user__button {
   all: unset;
   margin: 0 0 0 5rem;
@@ -104,6 +103,13 @@ a:active {
   align-items: center;
   justify-content: center;
   cursor: pointer;
+}
+
+.gnb__button {
+  margin: 0 0 0 5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .gnb__user__icon {
@@ -182,11 +188,11 @@ a:active {
     min-width: 58.8rem;
   }
 
-  .gnb__button {
+  .gnb__user__button {
     margin: 0 0 0 4rem;
   }
 
-  .gnb__user__button {
+  .gnb__button {
     margin: 0 0 0 4rem;
   }
 


### PR DESCRIPTION
Header.css 에서 `.gnb__user__button` 과 `.gnb__button` 의 위치를 변경하여 해결했습니다.
`all: unset` 설정이 중간에 적용되었던것이 원인이라 추측 중입니다.

추가로 유저 토글 버튼의 아이디가 특정 width(10rem)을 벗어날 경우 `...` 처리 했습니다.

![스크린샷 2022-07-02 오후 10 51 41](https://user-images.githubusercontent.com/74581396/177004917-8a0e58c0-f6d9-4679-af38-16dbb0a813ca.png)

