### PR TITLE
JIP-283 login register 간단 css 수정

### DIFF
--- a/src/css/Login.css
+++ b/src/css/Login.css
@@ -6,7 +6,7 @@
     background-color: #FFFFFF;
     width: 40rem;
     height: auto;
-    margin: 25rem auto;
+    margin: auto;
     border-radius: 1.5em;
     padding-top: 4.5rem;
     padding-bottom: 4rem;

--- a/src/css/Register.css
+++ b/src/css/Register.css
@@ -6,7 +6,7 @@
     background-color: #FFFFFF;
     width: 40rem;
     height: auto;
-    margin: 25rem auto;
+    margin: auto;
     border-radius: 1.5em;
     padding-top: 4.5rem;
     padding-bottom: 4rem;
@@ -102,5 +102,12 @@
 @media screen and (max-width:500px){
     .register-main {
         width: 95%;
+    }
+}
+
+@media screen and (max-width:450px){
+    .register-err {
+        color: orangered;
+        font-size: 1.1rem;
     }
 }


### PR DESCRIPTION
1. register, login 컴포넌트를 정중앙에 위치하게끔 설정
- 현재
<img width="858" alt="스크린샷 2022-07-03 오후 2 29 27" src="https://user-images.githubusercontent.com/48037775/177026305-0d309f98-5a43-4919-ba56-7ad9c58dbb35.png">

- 수정후 
<img width="891" alt="스크린샷 2022-07-03 오후 2 29 21" src="https://user-images.githubusercontent.com/48037775/177026308-bcff9cae-3009-4a2a-8b59-0ca3027d98f9.png">

2. register에서 패스워드 오류시 폰트 사이즈 조절
- 현재
<img width="344" alt="스크린샷 2022-07-03 오후 2 30 56" src="https://user-images.githubusercontent.com/48037775/177026337-fc555bbd-8a76-4f8c-a929-ddac32146d3d.png">

- 수정후
<img width="345" alt="스크린샷 2022-07-03 오후 2 31 06" src="https://user-images.githubusercontent.com/48037775/177026342-9a44a2d2-8799-4dda-ade8-a4de129cbc77.png">
