### PR TITLE
Jip 288 화면이 360 px 보다 작을 때 모바일 헤더 모달 위치 오류

### DIFF
--- a/src/component/utils/MobileHeader.js
+++ b/src/component/utils/MobileHeader.js
@@ -16,7 +16,7 @@ const MobileHeader = ({ location }) => {
   };
 
   const stickyHeader = () => {
-    if (window.pageYOffset >= 17) {
+    if (window.pageYOffset > 0) {
       setFixed(true);
     } else {
       setFixed(false);

--- a/src/css/HeaderModal.css
+++ b/src/css/HeaderModal.css
@@ -100,6 +100,9 @@
 
 .profile__text {
   margin-left: 1.5rem;
+  width: 15rem;
+  text-overflow: ellipsis;
+  overflow: hidden;
 }
 
 .header-modal__icon-book {

--- a/src/css/MobileHeader.css
+++ b/src/css/MobileHeader.css
@@ -1,7 +1,7 @@
 .mobile-header {
   width: 100%;
   margin: auto;
-  position: absolute;
+  position: fixed;
   z-index: 2;
   top: 0;
   left: 50%;


### PR DESCRIPTION
최소화면보다 작아질경우 헤더 모달의 위치가 바뀌는 오류를 수정했습니다.

https://user-images.githubusercontent.com/74581396/177036451-d8a0bf5d-0c31-49e6-916f-d6606deb3fea.mov

