### PR TITLE
Jip 300 마이페이지 qa 1 차 수정

### DIFF
--- a/src/component/mypage/EditEmail.js
+++ b/src/component/mypage/EditEmail.js
@@ -35,7 +35,7 @@ function EditEmail() {
         setIsGoBack(true);
       })
       .catch(err => {
-        const errorCode = err.response.data.errCode;
+        const { errorCode } = err.response.data;
         setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
@@ -56,7 +56,7 @@ function EditEmail() {
       })
       .then(res => setUserInfo(res.data.items[0]))
       .catch(err => {
-        const errorCode = err.response.data.errCode;
+        const { errorCode } = err.response.data;
         setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });

--- a/src/component/mypage/EditEmail.js
+++ b/src/component/mypage/EditEmail.js
@@ -5,6 +5,7 @@ import arrowLeft from "../../img/arrow_left_black.svg";
 import "../../css/EditEmail.css";
 import MiniModal from "../utils/MiniModal";
 import ModalContentsOnlyTitle from "../utils/ModalContentsOnlyTitle";
+import getErrorMessage from "../../data/error";
 
 function EditEmail() {
   const history = useHistory();
@@ -34,7 +35,8 @@ function EditEmail() {
         setIsGoBack(true);
       })
       .catch(err => {
-        setMiniModalContent(err.message);
+        const errorCode = err.response.data.errCode;
+        setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
   };
@@ -54,7 +56,8 @@ function EditEmail() {
       })
       .then(res => setUserInfo(res.data.items[0]))
       .catch(err => {
-        setMiniModalContent(err.message);
+        const errorCode = err.response.data.errCode;
+        setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
   }, []);

--- a/src/component/mypage/EditPassword.js
+++ b/src/component/mypage/EditPassword.js
@@ -44,7 +44,7 @@ function EditPassword() {
         setIsGoBack(true);
       })
       .catch(err => {
-        const errorCode = err.response.data.errCode;
+        const { errorCode } = err.response.data;
         setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });

--- a/src/component/mypage/EditPassword.js
+++ b/src/component/mypage/EditPassword.js
@@ -5,6 +5,7 @@ import arrowLeft from "../../img/arrow_left_black.svg";
 import "../../css/EditPassword.css";
 import MiniModal from "../utils/MiniModal";
 import ModalContentsOnlyTitle from "../utils/ModalContentsOnlyTitle";
+import getErrorMessage from "../../data/error";
 
 function EditPassword() {
   const history = useHistory();
@@ -43,7 +44,8 @@ function EditPassword() {
         setIsGoBack(true);
       })
       .catch(err => {
-        setMiniModalContent(err.message);
+        const errorCode = err.response.data.errCode;
+        setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
   };

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -65,7 +65,9 @@ const Mypage = () => {
   };
 
   useEffect(async () => {
-    await getUserInfo();
+    if (JSON.parse(window.localStorage.getItem("user")).isLogin)
+      await getUserInfo();
+    else history.push("/");
   }, []);
 
   useEffect(() => {

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -68,7 +68,7 @@ const Mypage = () => {
   useEffect(async () => {
     if (JSON.parse(window.localStorage.getItem("user")).isLogin)
       await getUserInfo();
-    else history.push("/");
+    else history.push("/login");
   }, []);
 
   useEffect(() => {

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -36,7 +36,8 @@ const Mypage = () => {
       })
       .then(res => setUserInfo(res.data.items[0]))
       .catch(err => {
-        setMiniModalContent(err.message);
+        const errorCode = err.response.data.errCode;
+        setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
   };

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -36,7 +36,7 @@ const Mypage = () => {
       })
       .then(res => setUserInfo(res.data.items[0]))
       .catch(err => {
-        const errorCode = err.response.data.errCode;
+        const { errorCode } = err.response.data;
         setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });

--- a/src/component/mypage/MypageReservedBook.js
+++ b/src/component/mypage/MypageReservedBook.js
@@ -17,7 +17,7 @@ const MypageReservedBook = ({
         setIsMiniModalOpen(true);
       })
       .catch(err => {
-        const errorCode = err.response.data.errCode;
+        const { errorCode } = err.response.data;
         setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });

--- a/src/component/mypage/MypageReservedBook.js
+++ b/src/component/mypage/MypageReservedBook.js
@@ -2,6 +2,7 @@ import React from "react";
 import "../../css/MypageReservedBook.css";
 import axios from "axios";
 import PropTypes from "prop-types";
+import getErrorMessage from "../../data/error";
 
 const MypageReservedBook = ({
   reserveInfo,
@@ -16,7 +17,8 @@ const MypageReservedBook = ({
         setIsMiniModalOpen(true);
       })
       .catch(err => {
-        setMiniModalContent(err.message);
+        const errorCode = err.response.data.errCode;
+        setMiniModalContent(getErrorMessage(errorCode));
         setIsMiniModalOpen(true);
       });
   };

--- a/src/css/Mypage.css
+++ b/src/css/Mypage.css
@@ -19,8 +19,8 @@
 .mypage-subtitle__user__info {
   display: flex;
   justify-content: space-between;
-  height: 23rem;
-  margin-bottom: 5rem;
+  height: 26rem;
+  margin-bottom: 3rem;
 }
 
 .mypage-subtitle__titlebox {
@@ -37,8 +37,11 @@
   letter-spacing: normal;
   text-align: left;
   color: #2d2d2d;
-  word-break: keep-all;
   white-space: normal;
+}
+
+.mypage-subtitle__titlebox__title > span {
+  word-break: break-all;
 }
 
 .mypage-subtitle__titlebox__guide__1 {
@@ -56,6 +59,7 @@
 
 .mypage-inquire-box-short-wrapper .inquire-box-title {
   height: 6rem;
+  min-width: unset;
 }
 
 .mypage-inquire-box-short-wrapper .inquire-box-title__icon {
@@ -75,6 +79,11 @@
   border-bottom-left-radius: 6.1rem;
   border-bottom-right-radius: 6.1rem;
   padding: 5rem 4rem 3rem 4rem;
+  white-space: break-spaces;
+}
+
+.mypage-inquire-box-short > span {
+  word-break: break-all;
 }
 
 .mypage-inquire-box-short-clickBox {
@@ -133,6 +142,7 @@
     margin-bottom: 0;
   }
   .mypage-inquire-box-long-wrapper .inquire-box-title {
+    min-width: unset;
     height: 6rem;
   }
   .mypage-inquire-box-long-wrapper .inquire-box-title__icon {

--- a/src/css/Mypage.css
+++ b/src/css/Mypage.css
@@ -27,6 +27,7 @@
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+  gap: 2rem;
   max-width: 55rem;
 }
 


### PR DESCRIPTION
## 1. 로그인하지 않은 유저 처리

**로그인하지 않은 유저는 바로 홈으로 돌아가게 만들었습니다.** 

사실 로그인하지 않은 유저가 mypage로 올 수 있는 방법이 직접 주소창에 치는 수밖에 없습니다. 
다만 마이페이지를 켜둔채로 토큰이 만료되거나 하는 상황을 대비해서, 로그인 페이지로 넘어가게 만들었습니다.

## 2. 길이가 길면 다음 줄로 모두 넘어가게 만들었습니다.

<img width="600" alt="image" src="https://user-images.githubusercontent.com/79993356/177311013-b94dc7a5-16c9-428b-b076-f188478a1c79.png">

유저 정보 및 대출 책 정보, 예약 책 정보에서도 모두 새로운 줄로 넘어가게 됩니다.

## 3. 기존 에러 처리를 error.js 에 맞게 수정했습니다.

FileChanges 에서 더욱 확실하게 보실 수 있어요!