### PR TITLE
JIP-313 메인 신작도서 이미지 조절 및 깨진 이미지 대체

### DIFF
--- a/src/component/main/MainNew.js
+++ b/src/component/main/MainNew.js
@@ -6,19 +6,6 @@ import SubTitle from "../utils/SubTitle";
 import MainNewBookList from "./MainNewBookList";
 import "../../css/MainNew.css";
 
-function useWidth() {
-  const [widthSize, setWidthSize] = useState(undefined);
-  useEffect(() => {
-    function handleSize() {
-      setWidthSize(window.innerWidth);
-    }
-    window.addEventListener("resize", handleSize);
-    handleSize();
-    return () => window.removeEventListener("resize", handleSize);
-  }, []);
-  return widthSize;
-}
-
 const MainNew = () => {
   const [docs, setDocs] = useState([]);
   const setGlobalError = useSetRecoilState(globalModal);
@@ -46,9 +33,6 @@ const MainNew = () => {
       });
   }, []);
 
-  const display = Math.ceil((useWidth() - 266) / 236);
-  const books = [...docs.slice(-1), ...docs, ...docs.slice(0, display + 1)];
-
   return (
     <section className="main-new">
       <div className="main-new__wrapper">
@@ -57,7 +41,7 @@ const MainNew = () => {
           description="책을 클릭하면 더 자세한 정보를 확인할 수 있습니다."
           alignItems="center"
         />
-        <MainNewBookList books={books} display={display} />
+        <MainNewBookList docs={docs} />
       </div>
     </section>
   );

--- a/src/component/main/MainNewBook.js
+++ b/src/component/main/MainNewBook.js
@@ -3,12 +3,15 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import IMGERR from "../../img/image_onerror.svg";
 
-const MainNewBook = ({ book }) => {
+const MainNewBook = ({ book, bookSize }) => {
   function subtituteImg(e) {
     e.target.src = IMGERR;
   }
   return (
-    <div className="main-new__book">
+    <div
+      className="main-new__book"
+      style={{ width: bookSize, height: bookSize * 1.5 }}
+    >
       <Link
         to={{
           pathname: `/info/${book.id}`,
@@ -18,6 +21,7 @@ const MainNewBook = ({ book }) => {
         }}
       >
         <img
+          style={{ width: bookSize, height: bookSize * 1.5 }}
           className="main-new__book-img"
           src={book.image}
           alt="new"
@@ -35,4 +39,5 @@ MainNewBook.propTypes = {
     id: PropTypes.number,
     image: PropTypes.string,
   }).isRequired,
+  bookSize: PropTypes.number.isRequired,
 };

--- a/src/component/main/MainNewBook.js
+++ b/src/component/main/MainNewBook.js
@@ -3,14 +3,14 @@ import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
 import IMGERR from "../../img/image_onerror.svg";
 
-const MainNewBook = ({ book, bookSize }) => {
+const MainNewBook = ({ book, bookWidth }) => {
   function subtituteImg(e) {
     e.target.src = IMGERR;
   }
   return (
     <div
       className="main-new__book"
-      style={{ width: bookSize, height: bookSize * 1.5 }}
+      style={{ width: bookWidth, height: bookWidth * 1.5 }}
     >
       <Link
         to={{
@@ -22,7 +22,7 @@ const MainNewBook = ({ book, bookSize }) => {
       >
         {book.image ? (
           <img
-            style={{ width: bookSize, height: bookSize * 1.5 }}
+            style={{ width: bookWidth, height: bookWidth * 1.5 }}
             src={book.image}
             alt="new"
             onError={subtituteImg}
@@ -43,5 +43,5 @@ MainNewBook.propTypes = {
     image: PropTypes.string,
     title: PropTypes.string,
   }).isRequired,
-  bookSize: PropTypes.number.isRequired,
+  bookWidth: PropTypes.number.isRequired,
 };

--- a/src/component/main/MainNewBook.js
+++ b/src/component/main/MainNewBook.js
@@ -20,13 +20,16 @@ const MainNewBook = ({ book, bookSize }) => {
           },
         }}
       >
-        <img
-          style={{ width: bookSize, height: bookSize * 1.5 }}
-          className="main-new__book-img"
-          src={book.image}
-          alt="new"
-          onError={subtituteImg}
-        />
+        {book.image ? (
+          <img
+            style={{ width: bookSize, height: bookSize * 1.5 }}
+            src={book.image}
+            alt="new"
+            onError={subtituteImg}
+          />
+        ) : (
+          <p className="main-new__book-sub-img">{book.title}</p>
+        )}
       </Link>
     </div>
   );
@@ -38,6 +41,7 @@ MainNewBook.propTypes = {
   book: PropTypes.shape({
     id: PropTypes.number,
     image: PropTypes.string,
+    title: PropTypes.string,
   }).isRequired,
   bookSize: PropTypes.number.isRequired,
 };

--- a/src/component/main/MainNewBookList.js
+++ b/src/component/main/MainNewBookList.js
@@ -116,7 +116,7 @@ const MainNewBookList = ({ docs }) => {
           onMouseLeave={startInterval}
         >
           {books.map(book => (
-            <MainNewBook book={book} bookSize={bookWidth} />
+            <MainNewBook book={book} bookWidth={bookWidth} />
           ))}
         </div>
       </div>

--- a/src/component/main/MainNewBookList.js
+++ b/src/component/main/MainNewBookList.js
@@ -5,38 +5,29 @@ import MainNewBookPagination from "./MainNewBookPagination";
 import ArrLeft from "../../img/arrow_left.svg";
 import ArrRight from "../../img/arrow_right.svg";
 
-function useWidth() {
-  const [widthSize, setWidthSize] = useState(undefined);
+const mobileWidth = 100;
+const pcWidth = 200;
+
+const MainNewBookList = ({ docs }) => {
+  const [page, setPage] = useState(1);
+  const [bookWidth, setBookWidth] = useState(pcWidth);
+  const [transition, setTransition] = useState(true);
+  const [displayCount, setDisplayCount] = useState(0);
+  const intervalId = useRef(0);
+
   useEffect(() => {
     function handleSize() {
-      setWidthSize(window.innerWidth);
+      const width = window.innerWidth < 767 ? mobileWidth : pcWidth;
+      if (width !== bookWidth) setBookWidth(width);
+      const count = Math.ceil(window.innerWidth / (width * 1.1));
+      if (count !== displayCount) setDisplayCount(count);
     }
     window.addEventListener("resize", handleSize);
     handleSize();
     return () => window.removeEventListener("resize", handleSize);
-  }, []);
-  return widthSize;
-}
+  }, [bookWidth, displayCount]);
 
-const MainNewBookList = ({ docs }) => {
-  const [page, setPage] = useState(1);
-  const [bookWidth, setBookWidth] = useState(200);
-  const [transition, setTransition] = useState(true);
-  const intervalId = useRef(0);
-
-  const displayCount = Math.ceil(useWidth() / (bookWidth + 10));
   const books = [...docs.slice(-1), ...docs, ...docs.slice(0, displayCount)];
-
-  useEffect(() => {
-    if (window.innerWidth < 767 && bookWidth !== 100) setBookWidth(100);
-    if (window.innerWidth >= 767 && bookWidth !== 200) setBookWidth(200);
-  }, [window.innerWidth]);
-
-  useEffect(() => {
-    if (window.innerWidth < 767 && bookWidth !== 100) setBookWidth(100);
-    if (window.innerWidth >= 767 && bookWidth !== 200) setBookWidth(200);
-  }, [window.innerWidth]);
-
   const onNext = () => {
     const index = page;
     if (index === books.length - displayCount - 1) {
@@ -109,7 +100,7 @@ const MainNewBookList = ({ docs }) => {
           className={`${transition && "main-new__books"}`}
           style={{
             transform: `translate(${
-              +((bookWidth / 2) * 0.1) - (bookWidth + 20) * page * 0.1
+              +((bookWidth / 2) * 0.1) - bookWidth * 1.1 * page * 0.1
             }rem)`,
           }}
           onMouseEnter={pauseInterval}

--- a/src/component/main/MainNewBookList.js
+++ b/src/component/main/MainNewBookList.js
@@ -5,14 +5,41 @@ import MainNewBookPagination from "./MainNewBookPagination";
 import ArrLeft from "../../img/arrow_left.svg";
 import ArrRight from "../../img/arrow_right.svg";
 
-const MainNewBookList = ({ books, display }) => {
+function useWidth() {
+  const [widthSize, setWidthSize] = useState(undefined);
+  useEffect(() => {
+    function handleSize() {
+      setWidthSize(window.innerWidth);
+    }
+    window.addEventListener("resize", handleSize);
+    handleSize();
+    return () => window.removeEventListener("resize", handleSize);
+  }, []);
+  return widthSize;
+}
+
+const MainNewBookList = ({ docs }) => {
   const [page, setPage] = useState(1);
+  const [bookSize, setBookSize] = useState(220);
   const [transition, setTransition] = useState(true);
   const intervalId = useRef(0);
 
+  const display = Math.ceil((useWidth() - bookSize) / (bookSize + 10));
+  const books = [...docs.slice(-2), ...docs, ...docs.slice(0, display + 1)];
+
+  useEffect(() => {
+    if (window.innerWidth < 767 && bookSize !== 100) setBookSize(110);
+    if (window.innerWidth >= 767 && bookSize !== 200) setBookSize(220);
+  }, [window.innerWidth]);
+
+  useEffect(() => {
+    if (window.innerWidth < 767 && bookSize !== 100) setBookSize(110);
+    if (window.innerWidth >= 767 && bookSize !== 200) setBookSize(220);
+  }, [window.innerWidth]);
+
   const onNext = () => {
     const index = page;
-    if (index === books.length - display - 2) {
+    if (index === books.length - display - 3) {
       setTransition(false);
       setPage(0);
       setTimeout(() => {
@@ -24,7 +51,7 @@ const MainNewBookList = ({ books, display }) => {
 
   const onPrev = () => {
     let index = page;
-    if (index === 0) {
+    if (index === 1) {
       index = books.length - display - 2;
       setTransition(false);
       setPage(index);
@@ -51,21 +78,45 @@ const MainNewBookList = ({ books, display }) => {
 
   return (
     <div className="main-new__content">
-      <button className="main-new__arrow" onClick={onPrev} type="button">
-        <img src={ArrLeft} alt="" />
+      <button
+        className="main-new__arrow"
+        onClick={onPrev}
+        type="button"
+        onMouseEnter={pauseInterval}
+        onMouseLeave={startInterval}
+      >
+        <img
+          src={ArrLeft}
+          alt=""
+          style={{ width: bookSize / 4, height: bookSize * 1.5 + 20 }}
+        />
       </button>
-      <button className="main-new__arrow right" onClick={onNext} type="button">
-        <img src={ArrRight} alt="" />
-      </button>{" "}
+      <button
+        className="main-new__arrow right"
+        onClick={onNext}
+        type="button"
+        onMouseEnter={pauseInterval}
+        onMouseLeave={startInterval}
+      >
+        <img
+          src={ArrRight}
+          alt=""
+          style={{ width: bookSize / 4, height: bookSize * 1.5 + 20 }}
+        />
+      </button>
       <div className="main-new__booklist">
         <div
           className={`${transition && "main-new__books"}`}
-          style={{ transform: `translate(${-92 - 236 * page * 0.1}rem)` }}
+          style={{
+            transform: `translate(${
+              -(bookSize / 6) - (bookSize + 20) * page * 0.1
+            }rem)`,
+          }}
           onMouseEnter={pauseInterval}
           onMouseLeave={startInterval}
         >
           {books.map(book => (
-            <MainNewBook book={book} />
+            <MainNewBook book={book} bookSize={bookSize} />
           ))}
         </div>
       </div>
@@ -77,6 +128,5 @@ const MainNewBookList = ({ books, display }) => {
 export default MainNewBookList;
 
 MainNewBookList.propTypes = {
-  books: PropTypes.arrayOf(PropTypes.object).isRequired,
-  display: PropTypes.number.isRequired,
+  docs: PropTypes.arrayOf(PropTypes.object).isRequired,
 };

--- a/src/component/main/MainNewBookList.js
+++ b/src/component/main/MainNewBookList.js
@@ -20,26 +20,26 @@ function useWidth() {
 
 const MainNewBookList = ({ docs }) => {
   const [page, setPage] = useState(1);
-  const [bookSize, setBookSize] = useState(220);
+  const [bookWidth, setBookWidth] = useState(200);
   const [transition, setTransition] = useState(true);
   const intervalId = useRef(0);
 
-  const display = Math.ceil((useWidth() - bookSize) / (bookSize + 10));
-  const books = [...docs.slice(-2), ...docs, ...docs.slice(0, display + 1)];
+  const displayCount = Math.ceil(useWidth() / (bookWidth + 10));
+  const books = [...docs.slice(-1), ...docs, ...docs.slice(0, displayCount)];
 
   useEffect(() => {
-    if (window.innerWidth < 767 && bookSize !== 100) setBookSize(110);
-    if (window.innerWidth >= 767 && bookSize !== 200) setBookSize(220);
+    if (window.innerWidth < 767 && bookWidth !== 100) setBookWidth(100);
+    if (window.innerWidth >= 767 && bookWidth !== 200) setBookWidth(200);
   }, [window.innerWidth]);
 
   useEffect(() => {
-    if (window.innerWidth < 767 && bookSize !== 100) setBookSize(110);
-    if (window.innerWidth >= 767 && bookSize !== 200) setBookSize(220);
+    if (window.innerWidth < 767 && bookWidth !== 100) setBookWidth(100);
+    if (window.innerWidth >= 767 && bookWidth !== 200) setBookWidth(200);
   }, [window.innerWidth]);
 
   const onNext = () => {
     const index = page;
-    if (index === books.length - display - 3) {
+    if (index === books.length - displayCount - 1) {
       setTransition(false);
       setPage(0);
       setTimeout(() => {
@@ -52,7 +52,7 @@ const MainNewBookList = ({ docs }) => {
   const onPrev = () => {
     let index = page;
     if (index === 1) {
-      index = books.length - display - 2;
+      index = books.length - displayCount;
       setTransition(false);
       setPage(index);
       setTimeout(() => {
@@ -88,7 +88,7 @@ const MainNewBookList = ({ docs }) => {
         <img
           src={ArrLeft}
           alt=""
-          style={{ width: bookSize / 4, height: bookSize * 1.5 + 20 }}
+          style={{ width: bookWidth / 4, height: bookWidth * 1.5 + 20 }}
         />
       </button>
       <button
@@ -101,7 +101,7 @@ const MainNewBookList = ({ docs }) => {
         <img
           src={ArrRight}
           alt=""
-          style={{ width: bookSize / 4, height: bookSize * 1.5 + 20 }}
+          style={{ width: bookWidth / 4, height: bookWidth * 1.5 + 20 }}
         />
       </button>
       <div className="main-new__booklist">
@@ -109,14 +109,14 @@ const MainNewBookList = ({ docs }) => {
           className={`${transition && "main-new__books"}`}
           style={{
             transform: `translate(${
-              -(bookSize / 6) - (bookSize + 20) * page * 0.1
+              +((bookWidth / 2) * 0.1) - (bookWidth + 20) * page * 0.1
             }rem)`,
           }}
           onMouseEnter={pauseInterval}
           onMouseLeave={startInterval}
         >
           {books.map(book => (
-            <MainNewBook book={book} bookSize={bookSize} />
+            <MainNewBook book={book} bookSize={bookWidth} />
           ))}
         </div>
       </div>

--- a/src/css/MainNew.css
+++ b/src/css/MainNew.css
@@ -74,6 +74,16 @@
   margin-top: 1rem;
 }
 
+.main-new__book-sub-img {
+  width: 100%;
+  height: 100%;
+  background-color: #a4a4a4;
+  box-sizing: border-box;
+  padding: 20%;
+  color: #a4a4a4;
+  font-weight: bold;
+}
+
 .main-new__books_pagination {
   position: absolute;
   bottom: 0;

--- a/src/css/MainNew.css
+++ b/src/css/MainNew.css
@@ -10,8 +10,6 @@
 }
 
 .main-new__arrow {
-  width: 8rem;
-  height: 34rem;
   margin: 0;
   position: absolute;
   top: 27.5rem;
@@ -48,8 +46,6 @@
 
 .main-new__book {
   text-align: none;
-  width: 21.6rem;
-  height: 32rem;
   display: inline-block;
   margin-left: 2rem;
   vertical-align: top;
@@ -64,11 +60,6 @@
   transform: scale(1.05);
   transition: all 0.3s ease-in-out;
   -webkit-transition: 0.3s;
-}
-
-.main-new__book-img {
-  width: 21.6rem;
-  height: 32rem;
 }
 
 .main-new__book:first-child {
@@ -109,4 +100,10 @@
 
 .main-new__books_pag_circle.selected {
   background-color: #2d2d2d;
+}
+
+@media screen and (max-width:767px) {
+  .main-new {
+    height: 52rem;
+  }
 }

--- a/src/css/MainNew.css
+++ b/src/css/MainNew.css
@@ -116,4 +116,8 @@
   .main-new {
     height: 52rem;
   }
+
+  .main-new__book {
+    margin-left:1rem;
+  }
 }


### PR DESCRIPTION
## 요약
모바일 화면에서 메인페이지의 신작도서 이미지가 작아지도록 변경하였습니다
이미지가 없는 경우 회색 이미지로 대체됩니다
<img width="300" alt="스크린샷 2022-07-07 오후 8 38 03" src="https://user-images.githubusercontent.com/74622889/177764899-1da3d23b-dda0-4bd7-85e5-ee6701f13303.png"> <img width="300" alt="스크린샷 2022-07-07 오후 8 38 57" src="https://user-images.githubusercontent.com/74622889/177764913-a2aface4-568c-4ec9-9c4e-003e3ce37e87.png">

## 수정사항
- css 대신 js 파일에서 width 설정하도록 변경했습니다
- window.innerWidth를 감지해서 모바일 화면일때 width를 줄여줍니다.
- js 컴포넌트마다 역할을 분명히 했습니다 

### 컴포넌트 별 역할
- mainNew : api 호출 및 데이터 저장
- mainNewBookList : 버튼 및 이벤트 동작 설정
- mainNewBook : 책 노출 방식 결정 이미지가 없는 경우 회색 면으로 대체
