### PR TITLE
Jip 305 예약 대출 페이지 qa 1 차 수정

### DIFF
--- a/src/component/reservedloan/ReservedModal.js
+++ b/src/component/reservedloan/ReservedModal.js
@@ -24,7 +24,7 @@ const ReservedModal = ({ reservedInfo, closeModal }) => {
           {lendResult ? (
             <ModalContentsTitleWithMessage
               closeModal={closeMiniModal}
-              title="대출이 완료되었습니다."
+              title={miniModalContents}
               message={reservedInfo.title}
             />
           ) : (

--- a/src/component/reservedloan/ReservedModalContents.js
+++ b/src/component/reservedloan/ReservedModalContents.js
@@ -77,20 +77,33 @@ const ReservedModalContents = ({
           <p className="mid-modal__book-title font-28-bold color-54  margin-8">
             {reservedInfo.title}
           </p>
-          <p className="font-16 color-54">{`도서코드 : ${reservedInfo.callSign}`}</p>
+          {reservedInfo.bookId && reservedInfo.callSign ? (
+            <p className="font-16 color-54">{`도서코드 : ${reservedInfo.callSign}`}</p>
+          ) : null}
         </div>
-        <div className="mid-modal__lend">
-          <p className="font-16 color-red">예약 만료일</p>
-          <p className="font-28-bold color-54  margin-8">
-            {reservedInfo.endAt ? reservedInfo.endAt.slice(0, 10) : "NULL"}
-          </p>
-        </div>
+        {reservedInfo.bookId && reservedInfo.endAt ? (
+          <div className="mid-modal__lend">
+            <p className="font-16 color-red">예약 만료일</p>
+            <p className="font-28-bold color-54  margin-8">
+              {reservedInfo.endAt ? reservedInfo.endAt.slice(0, 10) : "NULL"}
+            </p>
+          </div>
+        ) : (
+          <div className="mid-modal__lend">
+            <p className="font-16 color-red">예약 시작일</p>
+            <p className="font-28-bold color-54  margin-8">
+              {reservedInfo.createdAt
+                ? reservedInfo.createdAt.slice(0, 10)
+                : "NULL"}
+            </p>
+          </div>
+        )}
         <div className="mid-modal__user">
           <p className="font-16 color-red">유저정보</p>
           <p className="font-28-bold color-54  margin-8">
             {reservedInfo.login}
           </p>
-          <p className="font-16 color-54">{`연체일수 : ${reservedInfo.penaltyDays}`}</p>
+          <p className="font-16 color-54">{`연체일수 : ${reservedInfo.penaltyDays}일`}</p>
         </div>
         <div className="mid-modal__remark">
           <p className="font-16 color-red">비고</p>

--- a/src/component/reservedloan/ReservedModalContents.js
+++ b/src/component/reservedloan/ReservedModalContents.js
@@ -20,15 +20,13 @@ const ReservedModalContents = ({
     const condition = remark;
     setRemark("");
     await axios
-      .post(`${process.env.REACT_APP_API}/lendings`, [
-        {
-          userId: reservedInfo.userId,
-          bookId: reservedInfo.bookId,
-          condition,
-        },
-      ])
+      .post(`${process.env.REACT_APP_API}/lendings`, {
+        userId: reservedInfo.userId,
+        bookId: reservedInfo.bookId,
+        condition,
+      })
       .then(() => {
-        setMiniModalContents("success");
+        setMiniModalContents("대출이 완료되었습니다.");
         setLendResult(true);
       })
       .catch(error => {
@@ -49,7 +47,7 @@ const ReservedModalContents = ({
         `${process.env.REACT_APP_API}/reservations/cancel/${reservedInfo.reservationsId}`,
       )
       .then(() => {
-        setMiniModalContents("success");
+        setMiniModalContents("예약 취소가 완료되었습니다.");
         setLendResult(true);
       })
       .catch(error => {


### PR DESCRIPTION
## 1. 예약대출 예약 취소 모달 메시지 수정

<img width="600" alt="스크린샷 2022-07-08 오전 12 48 20" src="https://user-images.githubusercontent.com/79993356/177816469-e61058ec-73b9-47d4-9d7d-b926e8988647.png">

예약 취소를 누르면 뜬끔없이 대출이 완료되었다는 문구가 떴었는데 이를 수정했습니다.

## 2. 예약대출 bookId 가 없는 도서 수정

<img width="600" alt="스크린샷 2022-07-08 오전 12 48 01" src="https://user-images.githubusercontent.com/79993356/177816409-aaa17ff8-0d8f-4cb7-92e3-9352882c1976.png">

bookId 를 부여받지 못한 도서는 callsign 숨깁니다. 예약 만료일 대신 예약 시작일을 보여줍니다.

## 3. 백엔드 수정사항

다만 현재 reservation/search 로 받아오는 데이터에 문제가 있는 상황입니다. 프론트 컴포넌트에서는 이 데이터를 그대로 보여주고 있는데, 연체일이 제대로 나오고 있지 않습니다. 이는 추후에 서버개발자와 논의해야 합니다.