### PR TITLE
JIP-324 FIX: 날짜 형식 통일

### DIFF
--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -122,7 +122,7 @@ const BookDetail = ({ location, match }) => {
                 </div>
               </div>
               <div className="book-detail__info-wrapper color-54">
-                <div className="book-detail__info-key">발행연도</div>
+                <div className="book-detail__info-key">발행연월</div>
                 <div className="book-detail__info-value">
                   {bookDetailInfo.publishedAt}
                 </div>

--- a/src/component/book/BookStatus.js
+++ b/src/component/book/BookStatus.js
@@ -21,7 +21,7 @@ const BookStatus = ({ book, index }) => {
         {getBookStatus(book.isLendable, book.dueDate)}
       </div>
       <div className="book-status__dueDate">
-        {book.dueDate === "-" ? "-" : book.dueDate.substring(2, 10)}
+        {book.dueDate === "-" ? "-" : book.dueDate.slice(0, 10)}
       </div>
     </div>
   );

--- a/src/component/reservation/Reservation.js
+++ b/src/component/reservation/Reservation.js
@@ -20,7 +20,7 @@ const Reservation = ({ bookInfoId, closeModal, setClosable }) => {
         setReservationStep("success");
         if (response.data.count === 1) {
           const date = response.data.lenderableDate;
-          setPropsString(date.slice(2, 10).replaceAll("-", "."));
+          setPropsString(date.slice(0, 10));
         }
       })
       .catch(error => {

--- a/src/component/return/ReturnModalContents.js
+++ b/src/component/return/ReturnModalContents.js
@@ -80,8 +80,13 @@ const ReturnModalContents = ({
         </div>
         <div className="mid-modal__lend">
           <p className="font-16 color-red">대출정보</p>
-          <p className="font-28-bold color-54  margin-8">{data.createdAt}</p>
-          <p className="font-16 color-54">{`반납예정일 : ${data.dueDate}`}</p>
+          <p className="font-28-bold color-54  margin-8">
+            {data.createdAt.replaceAll(".", "-")}
+          </p>
+          <p className="font-16 color-54">{`반납예정일 : ${data.dueDate.replaceAll(
+            ".",
+            "-",
+          )}`}</p>
         </div>
         <div className="mid-modal__user">
           <p className="font-16 color-red">유저정보</p>

--- a/src/component/search/BookInfo.js
+++ b/src/component/search/BookInfo.js
@@ -66,9 +66,11 @@ const BookInfo = ({
             <span>{category}</span>
           </div>
           <div className="book-info__published-at font-16 color-54">
-            <span>발행연도</span>
+            <span>발행연월</span>
             <span className="book-info__separator-half" />
-            <span>{year && month ? `${year}.${month}` : "-"}</span>
+            <span>
+              {year && month ? `${year}년 ${parseInt(month, 10)}월` : "-"}
+            </span>
           </div>
           <div className="book-info__isbn font-16 color-54">
             <span>표준부호</span>


### PR DESCRIPTION
### 수정사항
- 검색 및 도서 상세 "발행연도" -> "발행연월" 로 문구 수정했습니다
- 검색 날짜 형식  yyyy-mm 월 -> yyyy-m월 도서 상세에서의 발행연월 형식과 통일했습니다
- 기타 날짜를 노출하는 부분에서는 yyyy-mm-dd 로 통일했습니다
<img width="428" alt="image" src="https://user-images.githubusercontent.com/74622889/177938765-f5a0cbfc-4d70-4ffa-8c4b-681c96e37b80.png">
<img width="648" alt="image" src="https://user-images.githubusercontent.com/74622889/177938693-22fa6d76-4783-4429-84fb-725e2a7951d8.png">
<img width="675" alt="image" src="https://user-images.githubusercontent.com/74622889/177938897-5c97c88d-aadc-4d39-8005-0e18704bfaaa.png">
<img width="655" alt="image" src="https://user-images.githubusercontent.com/74622889/177939416-a95c4048-e25a-46b4-8a6c-71655cad6280.png">
