### PR TITLE
JIP-329 REFACT: 유저 정보 수정할 시 BriefInfo 에 바로 반영

### DIFF
--- a/src/component/userManagement/UserBriefInfo.js
+++ b/src/component/userManagement/UserBriefInfo.js
@@ -4,7 +4,7 @@ import "../../css/UserBriefInfo.css";
 import UserUsage from "../../img/book-arrow-right.svg";
 import UserEdit from "../../img/edit.svg";
 
-const roles = ["미인증", "일반", "사서", "스태프"];
+const roles = ["미인증", "일반", "사서", "운영진"];
 const USAGE = 1;
 const EDIT = 2;
 

--- a/src/component/userManagement/UserDetailInfo.js
+++ b/src/component/userManagement/UserDetailInfo.js
@@ -76,6 +76,8 @@ const UserDetailInfo = ({
   setErrorCode,
   closeMidModal,
   openMiniModal,
+  isEdit,
+  setIsEdit,
 }) => {
   const today = new Date();
   const [editMode, setEditMode] = useState(false);
@@ -103,6 +105,7 @@ const UserDetailInfo = ({
         setUserSlack(userInfo.slack);
         setUserRoleNum(userInfo.role);
         setUserPenalty(userInfo.penaltyEndDate);
+        setIsEdit(!isEdit);
       })
       .catch(error => {
         closeMidModal();
@@ -263,6 +266,8 @@ UserDetailInfo.propTypes = {
   setErrorCode: PropTypes.func.isRequired,
   closeMidModal: PropTypes.func.isRequired,
   openMiniModal: PropTypes.func.isRequired,
+  isEdit: PropTypes.bool.isRequired,
+  setIsEdit: PropTypes.func.isRequired,
 };
 
 UserInfoEdit.propTypes = {

--- a/src/component/userManagement/UserManagement.js
+++ b/src/component/userManagement/UserManagement.js
@@ -29,6 +29,7 @@ const UserManagement = () => {
   const [lastUserListPage, setLastUserListPage] = useState(1);
   const [userList, setUserList] = useState([]);
   const [errorCode, setErrorCode] = useState(-1);
+  const [isEdit, setIsEdit] = useState(false);
 
   const closeModal = () => {
     setModal(0);
@@ -75,7 +76,7 @@ const UserManagement = () => {
       });
   };
 
-  useEffect(getUserList, [userSearchWord, userListPage]);
+  useEffect(getUserList, [userSearchWord, userListPage, isEdit]);
 
   useEffect(() => {
     setUserListPageRange(0);
@@ -155,6 +156,8 @@ const UserManagement = () => {
               setErrorCode={setErrorCode}
               closeMidModal={closeModal}
               openMiniModal={openMiniModal}
+              isEdit={isEdit}
+              setIsEdit={setIsEdit}
             />
           )}
         </MidModal>


### PR DESCRIPTION
- 모달에서 유저 정보 수정 시 새로고침을 하지 않아도 유저 정보 목록을 보여주는 페이지에 바로 반영 되도록 수정했습니다.

https://user-images.githubusercontent.com/74581396/177955520-a8f566ec-f28d-425d-8386-3fdc50f96589.mov

