### PR TITLE
JIP-327 FIX: 예약대출, 반납 페이지 검색어 변경시 Page 1로 초기화

### DIFF
--- a/src/component/reservedloan/ReservedLoan.js
+++ b/src/component/reservedloan/ReservedLoan.js
@@ -64,12 +64,16 @@ const ReservedLoan = () => {
     setLastresevedLoanPage(meta.totalPages);
   };
 
+  useEffect(async () => {
+    setResevedLoanPage(1);
+    await fetchReservedLoanData();
+  }, [userSearchWord]);
+
   useEffect(() => {
     setUserSearchWord("");
   }, []);
 
   useEffect(fetchReservedLoanData, [
-    userSearchWord,
     resevedLoanPage,
     isPending,
     isWaiting,

--- a/src/component/return/ReturnBook.js
+++ b/src/component/return/ReturnBook.js
@@ -60,7 +60,12 @@ const ReturnBook = () => {
     setUserSearchWord("");
   }, []);
 
-  useEffect(fetchreturnBookData, [userSearchWord, returnBookPage, lendingSort]);
+  useEffect(async () => {
+    setReturnBookPage(1);
+    await fetchreturnBookData();
+  }, [userSearchWord]);
+
+  useEffect(fetchreturnBookData, [returnBookPage, lendingSort]);
 
   useEffect(() => {
     const searchForm = document.querySelector(".modal-search-form");


### PR DESCRIPTION
### 개요

예약대출, 반납 페이지에서 검색어를 변경했음에도 불구하고, 검색할 페이지는 이전 값으로 설정되어 있는 오류가 있었습니다.
검색어와 연결된 useEffect를 설정해서 검색어 변경시 Page를 1로 설정해주고, 검색을 실행하게끔 했습니다.

### 이전
https://user-images.githubusercontent.com/48037775/178101561-1ababd39-5614-4c2c-b84d-1f7a129faab6.mov

### 이후
https://user-images.githubusercontent.com/48037775/178101608-95117371-ff48-497a-b371-cc959d10ef10.mov


