### PR TITLE
JIP-335 HOTFIX: 메인 publishedAt null일때 컴파일 에러 해결

### DIFF
--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -121,12 +121,14 @@ const BookDetail = ({ location, match }) => {
                   {bookDetailInfo.publisher}
                 </div>
               </div>
-              <div className="book-detail__info-wrapper color-54">
-                <div className="book-detail__info-key">발행연월</div>
-                <div className="book-detail__info-value">
-                  {bookDetailInfo.publishedAt}
+              {bookDetailInfo.publishedAt && (
+                <div className="book-detail__info-wrapper color-54">
+                  <div className="book-detail__info-key">발행연월</div>
+                  <div className="book-detail__info-value">
+                    {bookDetailInfo.publishedAt}
+                  </div>
                 </div>
-              </div>
+              )}
               <div className="book-detail__info-wrapper color-54">
                 <div className="book-detail__info-key">카테고리</div>
                 <div className="book-detail__info-value">

--- a/src/component/main/MainPopularCenter.js
+++ b/src/component/main/MainPopularCenter.js
@@ -108,7 +108,9 @@ const MainPopularCenter = ({ docs, centerTop, onLeft, onRight }) => {
                 >
                   <p>작가 | {book.author}</p>
                   <p>출판사 | {book.publisher}</p>
-                  <p>발행일자 | {book.publishedAt.slice(0, 10)}</p>
+                  {book.publishedAt && (
+                    <p>발행일자 | {book.publishedAt.slice(0, 10)}</p>
+                  )}
                 </div>
               </button>
             ))}

--- a/src/component/search/BookInfo.js
+++ b/src/component/search/BookInfo.js
@@ -23,7 +23,7 @@ const BookInfo = ({
     return { year, month, day };
   };
 
-  const { year, month } = parseDate(publishedAt);
+  const { year, month } = parseDate(publishedAt) ?? { year: 0, month: 0 };
 
   function subtituteImg(e) {
     e.target.src = IMGERR;


### PR DESCRIPTION
## 문제상황
- bookInfo table의 publishedAt 값이 nullable하게 바뀌면서 timezone 형식으로 예측한 속성에 적용한 함수가 컴파일 오류를 발생했습니다

## 수정사항
- publishedAt이 null 일때 발행일자 자체를 보이지 않도록 수정했습니다.

### 고려했던 해결방식
1. 옵셔널체이닝 `?` 추가
- 발행일자: null 로 표기되어 적절하지 않아보입니다.
<img width="509" alt="image" src="https://user-images.githubusercontent.com/74622889/178113266-2ce9062d-a877-4815-a914-7c2d2bd4757e.png">

2. null이면 값 자체를 "-"로 변경
- null이나 -나 큰 차이가 없어보입니다.
<img width="505" alt="image" src="https://user-images.githubusercontent.com/74622889/178113316-7b616e8d-ada8-45fd-8f1e-f589561cb5d1.png">

3. publishedAt이 없을 때 발행일자 p 태그 자체를 없애버리기
- 현재 진행중인 방식입니다
- 불필요한 html 태그를 남겨놓지 않도록 설정할 수 있습니다. html문서 안의 요소 적절성을 지킬 수 있습니다.
- 애매한 여백이 생깁니다
<img width="491" alt="image" src="https://user-images.githubusercontent.com/74622889/178113223-5f4f1134-2d1c-47a5-977e-0bf170de782b.png">

4. book.publishedAt이 없으면 이미지 크기 및 요소 크기 변경
- css로 해결할 수 없는 문제입니다. js에서 직접 요소의 style에 접근해서 바꿔야 합니다. 추후 수정하고 싶을 때 css 변동만으론 부족합니다
- 상황에 맞는 랜더링을 하기 위해 수많은 상태를 저장해야 합니다.
- 코드가 복잡해지고 처리하기 위한 시간이 많이 필요합니다.
- 펼쳐진 책의 상태에 따라 요소의 크기가 변동하여 푸터의 위치, 스크롤등의 변화가 생깁니다.

## 기타
- 백엔드에서 임의로 9999-01-01로 변경해서 보내주고 있어서 테스트를 거치지 못했습니다 (7/10 03:55 기준)
- bookinfo DB publishedAt에 연결된 데이터가 null이 가능해지면서 어떤 api가 영향을 받을지 예상되지 않습니다. 최대한 반영을 했으나 컴파일 오류가 특정페이지에서 발견될 수 있습니다. 추후 재확인이 필요합니다.
