### PR TITLE
JIP-346 FIX: 프론트에서 보이는 penaltyEndDate 기본값을 빈문자열로 설정

### DIFF
--- a/src/component/userManagement/UserDetailInfo.js
+++ b/src/component/userManagement/UserDetailInfo.js
@@ -126,13 +126,21 @@ const UserDetailInfo = ({
     const intraId = parseInt(intra, 10);
     const role = parseInt(roleNum, 10);
 
-    const data = {
-      nickname: nickname === "" ? null : nickname,
-      intraId: Number.isNaN(intraId) ? null : intraId,
-      slack: slack === "" ? null : slack,
-      role: Number.isNaN(role) ? 0 : role,
-      penaltyEndDate: penalty,
-    };
+    const data =
+      penalty && penalty !== ""
+        ? {
+            nickname: nickname === "" ? null : nickname,
+            intraId: Number.isNaN(intraId) ? null : intraId,
+            slack: slack === "" ? null : slack,
+            role: Number.isNaN(role) ? 0 : role,
+            penaltyEndDate: penalty,
+          }
+        : {
+            nickname: nickname === "" ? null : nickname,
+            intraId: Number.isNaN(intraId) ? null : intraId,
+            slack: slack === "" ? null : slack,
+            role: Number.isNaN(role) ? 0 : role,
+          };
     patchUserInfo(data);
     offEditMode();
   };
@@ -173,7 +181,7 @@ const UserDetailInfo = ({
             infoValue={
               userPenalty && userPenalty >= convertDatetoString(today)
                 ? userPenalty
-                : convertDatetoString(today)
+                : ""
             }
           />
           <UserInfoDisplay


### PR DESCRIPTION
- penaltyEndDate가 null 이거나 오늘 이전인 경우 프론트에서 보이는 penaltyEndDate 기본값을 오늘 -> 빈문자열로 수정했습니다.

https://user-images.githubusercontent.com/74581396/179339826-f97736bd-7332-4b58-81a0-5629e73545be.mov
