### PR TITLE
 JIP-352 ENV: aws cloudfront 무효화 생성 자동화

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,3 +46,4 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           aws s3 sync ./build s3://42library.kr --region ap-northeast-2
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} --paths "/*"


### PR DESCRIPTION
## 요약
수동으로 생성하던 무효화정책을 github action으로 처리하려 합니다. 

## 수정사항
### yml 파일 수정
Deploy run 다음 단계 추가          
` aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} --paths "/*"`

### github repository secret 추가 
Name: AWS_CDN_DISTRIBUTION_ID
Value : aws 콘솔에서 확인한 배포 id `E1IS2(이하 생략)` 42library.kr과 연결되어 있음


## 목적
s3 버킷을 갱신하더라도 CDN 엣지에 남아있는 캐시때문에 변경사항이 최대 24시간까지 반영되지 않을 수 있습니다. 
이 캐시를 지우기 위해 무효화가 필요합니다.


## reference 
https://docs.aws.amazon.com/ko_kr/AmazonCloudFront/latest/DeveloperGuide/Invalidation.html
https://kiwinam.com/posts/42/remove-cache-cloud-front/
https://hyeon9mak.github.io/cloudfront-caching-control-with-invalidations/