### PR TITLE
JIP-352 aws cloudfront 무효화 생성 자동화 (재시도)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,4 +46,11 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           aws s3 sync ./build s3://42library.kr --region ap-northeast-2
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} --paths "/*"
+
+      - name: invalidate CDN cache 
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_CDN_DISTRIBUTION_ID: ${{ secrets.AWS_CDN_DISTRIBUTION_ID }}
+        run: |
+          aws cloudfront create-invalidation --distribution-id ${{ secrets.AWS_CDN_DISTRIBUTION_ID }} --paths "/*" --region ap-northeast-2


### PR DESCRIPTION
## 요약
지난 캐시 무효화 시도 실패의 문제 해결

### 지난 시도의 문제점
- 프론트 배포에 쓰인 사용자의 IAM 권한이 없어 cloudfront 에 접근할 수 없었습니다. 
- 자격증명에 필요한 config 설정이 부족했습니다. github action에 기본 설정이 없기 때문에 region을 생략할 수 없습니다.

## 수정사항
- 배포(s3 빌드) 단계와 cloudfront 캐시 무효화 단계를 분리했습니다. 
- aws 자격증명 과정에서 필요한 region 설정을 추가했습니다. 
- aws IAM frontdeploy 권한에 CloudFront에 접근할 수 있는 권한을 추가했습니다. 

### 참고
- fork 한 레파지토리에서 yml 파일 실행  및 성공 여부를 확인했습니다. 

![github com_notusing11_frontend_actions_runs_2775270338_workflow](https://user-images.githubusercontent.com/74622889/182162379-1c6e1274-6a14-4c01-b0cc-dfe01631e1ac.png)

<img width="865" alt="image" src="https://user-images.githubusercontent.com/74622889/182165938-46960726-9c94-4136-ad07-1424a9f8a938.png">
