### PR TITLE
issue/264 인기도서 소개 문구 수정

### DIFF
--- a/src/component/main/MainPopular.js
+++ b/src/component/main/MainPopular.js
@@ -57,8 +57,8 @@ const MainPopular = () => {
     <section className="main__popular">
       <div className="main__popular__wrapper">
         <SubTitle
-          subTitle="이번 달 인기 도서를 소개합니다"
-          description="42서울 카뎃들이 이번 달 가장 많이 본 책들은 무엇일까요?"
+          subTitle="42일 인기 도서를 소개합니다"
+          description="42서울 카뎃들이 42일 동안 가장 많이 본 책들은 무엇일까요?"
           alignItems="start"
         />
         <div className="main__popular__contents">


### PR DESCRIPTION
> 요약

인기 도서 소개 문구를 수정했습니다.

> 변경사항

- [x]  인기 도서 문구의 메인 소개 글에서 "이번 달" -> "42일" 으로 수정
- [x] 인기 도서 문구의 부제에서 "이번 달" -> "42일 동안" 으로 수정


> 프리뷰
* Before
![image](https://user-images.githubusercontent.com/85930183/192903067-249afa7d-4dc6-45ca-b6a7-ccb394a8dcde.png)

* After 
<img width="603" alt="image" src="https://user-images.githubusercontent.com/85930183/192903129-47055b9d-a642-41e5-872e-f3c26090bdc2.png">

