### PR TITLE
Issue/262 라우터 코드 가독성 개선

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
 import React, { useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
-import { useRecoilState } from "recoil";
+import { useSetRecoilState } from "recoil";
 import { install } from "ga-gtag";
 import BookDetail from "./component/book/BookDetail";
 import Footer from "./component/utils/Footer";
@@ -25,9 +25,10 @@ import Mypage from "./component/mypage/Mypage";
 import EditEmail from "./component/mypage/EditEmail";
 import EditPassword from "./component/mypage/EditPassword";
 import "./css/reset.css";
+import LimitedRoute from "./LimitedRoute";
 
 function App() {
-  const [user, setUser] = useRecoilState(userState);
+  const setUser = useSetRecoilState(userState);
   useEffect(() => {
     install(process.env.REACT_APP_GA_ID);
     const localUser = JSON.parse(window.localStorage.getItem("user"));
@@ -52,21 +53,20 @@ function App() {
         <Route path="/auth" element={<Auth />} />
         <Route path="/logout" element={<Logout />} />
         <Route path="/register" element={<Register />} />
-        {user.isAdmin && <Route path="/rent" element={<Rent />} />}
-        {user.isAdmin && <Route path="/return" element={<ReturnBook />} />}
-        {user.isAdmin && (
+        <Route element={<LimitedRoute isAdminOnly />}>
+          <Route path="/rent" element={<Rent />} />
+          <Route path="/return" element={<ReturnBook />} />
           <Route path="/reservation" element={<ReservedLoan />} />
-        )}
-        {user.isAdmin && <Route path="/addbook" element={<AddBook />} />}
-        {user.isAdmin && <Route path="/user" element={<UserManagement />} />}
-
-        {user.isLogin && (
+          <Route path="/addbook" element={<AddBook />} />
+          <Route path="/user" element={<UserManagement />} />
+        </Route>
+        <Route element={<LimitedRoute isLoginOnly />}>
           <Route path="/mypage" element={<MyPageRoutes />}>
             <Route index element={<Mypage />} />
             <Route path="edit/email" element={<EditEmail />} />
             <Route path="edit/pw" element={<EditPassword />} />
           </Route>
-        )}
+        </Route>
         <Route path="*" element={<NotFound />} />
       </Routes>
       <Footer />

--- a/src/LimitedRoute.js
+++ b/src/LimitedRoute.js
@@ -1,0 +1,30 @@
+import React from "react";
+import { Navigate, Outlet } from "react-router-dom";
+import { useRecoilValue } from "recoil";
+import PropTypes from "prop-types";
+import NotFound from "./component/utils/NotFound";
+import userState from "./atom/userState";
+
+const LimitedRoute = ({ isLoginOnly, isAdminOnly }) => {
+  const user = useRecoilValue(userState);
+
+  if (isAdminOnly && !user.isAdmin) {
+    return <NotFound />;
+  }
+  if (isLoginOnly && !user.isLogin) {
+    return <Navigate to="/login" />;
+  }
+  return <Outlet />;
+};
+
+export default LimitedRoute;
+
+LimitedRoute.propTypes = {
+  isLoginOnly: PropTypes.bool,
+  isAdminOnly: PropTypes.bool,
+};
+
+LimitedRoute.defaultProps = {
+  isLoginOnly: false,
+  isAdminOnly: false,
+};

--- a/src/component/mypage/Mypage.js
+++ b/src/component/mypage/Mypage.js
@@ -66,9 +66,7 @@ const Mypage = () => {
   };
 
   useEffect(async () => {
-    if (JSON.parse(window.localStorage.getItem("user")).isLogin)
-      await getUserInfo();
-    else navigate("/login");
+    await getUserInfo();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 요약
> LimitedRoute 도입으로 가독성을 개선합니다. 

## 변경사항
- 라우트 단계에서 전역상태의 user 권한을 확인하는 LimitedRouter 추가
- isAdminOnly / isLoginOnly를 구분해서 라우터 페이지별 권한 명시
- 페이지 내에서 user권한을 확인하고 페이지 이동하는 코드 삭제 


## 프리뷰
### 기존 코드
<img width="817" alt="image" src="https://user-images.githubusercontent.com/74622889/194019457-2f7224e6-74aa-41f2-8a36-c3a57873481c.png">

### 변경 코드
<img width="655" alt="image" src="https://user-images.githubusercontent.com/74622889/194019308-3f487773-3ee7-4fa0-8c63-87332f5278a9.png">
