### PR TITLE
Issue/267 도서 상세 문구 수정

### DIFF
--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -106,7 +106,7 @@ const BookDetail = () => {
                   type="button"
                   disabled
                 >
-                  예약 불가
+                  대출 가능
                   <img src={ArrDef} alt="Arr" />
                 </button>
               )}

--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -142,6 +142,7 @@ const BookDetail = () => {
                 <div className="book-detail__info-key">기부자</div>
                 <div className="book-detail__info-value">
                   {bookDetailInfo.books.reduce((accumulator, current) => {
+                    if (!current.donator) return accumulator;
                     if (accumulator === "" || current.donator === "")
                       return accumulator + current.donator;
                     // eslint-disable-next-line prefer-template


### PR DESCRIPTION
## 요약
> 도서 상세 화면의 문구를 일부 수정합니다 

## 변경사항
- 기부자 null일 때 표시 안하도록
- 비치중인 책이 있어 예약 불가능일 때 문구 수정 예약 불가 -> 대출 가능

## 프리뷰
### 이전화면
<img width="652" alt="image" src="https://user-images.githubusercontent.com/74622889/194049006-68e39db0-3709-4087-ae80-fb1e3da953c7.png">

### 변경 후
<img width="650" alt="image" src="https://user-images.githubusercontent.com/74622889/194049034-5cb48c00-42a7-4130-8a24-7582a6bdbfe1.png">
