### PR TITLE
FIX: 도서 기부자 상태정보로 이동

### DIFF
--- a/src/component/book/BookDetail.js
+++ b/src/component/book/BookDetail.js
@@ -88,18 +88,6 @@ const BookDetail = () => {
                   {bookDetailInfo.category}
                 </div>
               </div>
-              <div className="book-detail__info-wrapper color-54">
-                <div className="book-detail__info-key">기부자</div>
-                <div className="book-detail__info-value">
-                  {bookDetailInfo.books.reduce((accumulator, current) => {
-                    if (!current.donator) return accumulator;
-                    if (accumulator === "" || current.donator === "")
-                      return accumulator + current.donator;
-                    // eslint-disable-next-line prefer-template
-                    return accumulator + ", " + current.donator;
-                  }, "")}
-                </div>
-              </div>
             </div>
             <div className="book-state">
               <span className="book-detail__info-status color-54">

--- a/src/component/book/BookStatus.js
+++ b/src/component/book/BookStatus.js
@@ -32,6 +32,9 @@ const BookStatus = ({ book, index }) => {
       <div className="book-status__dueDate">
         {book.dueDate === "-" ? "-" : book.dueDate.slice(0, 10)}
       </div>
+      {book.donator ? (
+        <div className="book-status__donator">{`${book.donator} 기부`}</div>
+      ) : null}
     </div>
   );
 };

--- a/src/css/BookStatus.css
+++ b/src/css/BookStatus.css
@@ -5,26 +5,30 @@
 }
 
 .book-status__id {
-  width: 2rem;
   margin-right: 3%;
 }
 
 .book-status__callSign {
-  margin-right: 4%;
-  width: 10rem;
+  margin-right: 3%;
   text-align: center;
 }
 
 .book-status__status {
-  margin-right: 5%;
-  width: 6rem;
+  margin-right: 2%;
   text-align: center;
 }
 
 .book-status__dueDate {
-  width: 5rem;
-  margin-right: 5%;
+  font-size: 1.6rem;
+  line-height: 1.8;
+  margin-right: 3%;
+  width: 9rem;
   text-align: center;
+}
+
+.book-status__donator {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .reservation-btn,
@@ -51,9 +55,15 @@
   margin-top: 0.3rem;
 }
 
-@media screen and (min-width: 768px) and (max-width: 1200px) {
+@media screen and (max-width: 767px) {
   .book-status {
     margin-bottom: 1rem;
-    font-size: 1.4rem;
+    font-size: 1.6rem;
+  }
+  .book-status > * {
+    margin-right: 5%;
+  }
+  .book-status__dueDate {
+    display: none;
   }
 }


### PR DESCRIPTION
## 요약
- 도서 상세페이지 기부자 정보 위치 이동

### 변경사항
- 개별 책 상태정보 옆에 기부자 표기
- 767px 이하 모바일 화면에서 반납예정일 생략

### preview

<img width="513" alt="image" src="https://user-images.githubusercontent.com/74622889/200807688-5d93c8f3-c526-4fd7-827a-c20cb4a46ea2.png">
<img width="414" alt="image" src="https://user-images.githubusercontent.com/74622889/200807756-be1d10ef-fa3e-4f34-a4b1-f8fd841e8cb2.png">
<img width="335" alt="image" src="https://user-images.githubusercontent.com/74622889/200807810-bb0bc226-8ba0-415a-9c74-6fbfb15cda0e.png">
<img width="291" alt="image" src="https://user-images.githubusercontent.com/74622889/200807853-d64b9e2b-aee2-47d2-b7bb-48d8944471f2.png">


### 특이사항
- 화면보다 기부자 이름이 긴 경우 생략될 수 있음 
<img width="394" alt="image" src="https://user-images.githubusercontent.com/74622889/200808389-413aaa6f-d779-4628-9d8e-54d7cc438d61.png">
<img width="288" alt="image" src="https://user-images.githubusercontent.com/74622889/200808454-578918d3-6ca5-45b6-8f2d-61e297d1fc97.png">

Resolves #288 