### PR TITLE
HOTFIX: 바코드로 대출할 때 오류 수정

### DIFF
--- a/src/api/books/useGetBooksId.js
+++ b/src/api/books/useGetBooksId.js
@@ -15,8 +15,9 @@ const useGetBooksId = ({ setSelectedBooks, closeModal }) => {
   ];
 
   const refineResponse = response => {
-    const book = compareExpect("books/:bookid", [response.data], expectedItem);
-    setSelectedBooks(prev => [...prev, ...book]);
+    const [book] = compareExpect("books/:id", [response.data], expectedItem);
+    book.bookId = book.id;
+    setSelectedBooks(prev => [...prev, book]);
     closeModal(false);
   };
 


### PR DESCRIPTION
## 요약
- 바코드 인식했을때 대출이 안되는 오류를 해결했습니다 

### 변경사항
- 바코드 인식후 가져오는 book 객체에 bookId 추가