### PR TITLE
FIX: 검색 검색어 변경시 url 카테고리 및 정렬 삭제

### DIFF
--- a/src/component/search/Search.js
+++ b/src/component/search/Search.js
@@ -27,6 +27,8 @@ const Search = () => {
       debounce(() => {
         urlSearchParams.set("search", newQuery);
         urlSearchParams.set("page", 1);
+        urlSearchParams.delete("category");
+        urlSearchParams.delete("sort");
         setUrlSearchParams(urlSearchParams);
       }, 500);
     },


### PR DESCRIPTION
## 요약


제보받은 문제를 해결했습니다.
검색어를 변경하면 카테고리가 초기화됩니다.
<img src="https://user-images.githubusercontent.com/74622889/211997518-35254c96-f233-45ee-a2b5-ab32957e78ee.gif" alt="해결">


### 문제상황
검색어 변경에도 이전에 선택한 카테고리가 유지됨

### 원인
검색어 변경시 url에서 검색어와 페이지만 수정하고 있었음

## 변경사항
검색어 변경시 카테고리 및 정렬도 초기화하도록 추가




resolve #348 