### PR TITLE
Issue/359 도서 분실확인용 페이지

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -29,6 +29,7 @@ import LimitedRoute from "./LimitedRoute";
 import { isExpiredDate } from "./util/date";
 import BookManagement from "./component/bookManagement/BookManagement";
 import ReviewManagement from "./component/reviewManagement/ReviewManagement";
+import BookStock from "./component/bookStock/BookStock";
 
 function App() {
   const setUser = useSetRecoilState(userState);
@@ -67,6 +68,7 @@ function App() {
           <Route path="/history" element={<History />} />
           <Route path="/book" element={<BookManagement />} />
           <Route path="/review" element={<ReviewManagement />} />
+          <Route path="/stock" element={<BookStock />} />
         </Route>
         <Route element={<LimitedRoute isLoginOnly />}>
           <Route path="/mypage" element={<MyPageRoutes />}>

--- a/src/api/books/useGetBooksIdForStock.js
+++ b/src/api/books/useGetBooksIdForStock.js
@@ -1,0 +1,42 @@
+import { useState, useEffect } from "react";
+import { setErrorDialog } from "../../data/error";
+import useApi from "../../hook/useApi";
+import { compareExpect } from "../../util/typeCheck";
+
+const useGetBooksIdForStock = ({ id, setOpenTitleAndMessage, closeModal }) => {
+  const [bookDetail, setBookDetail] = useState({});
+  const { request } = useApi("get", `books/${id}`);
+
+  const expectedItem = [
+    { key: "bookId", type: "number", isNullable: false },
+    { key: "bookInfoId", type: "number", isNullable: false },
+    { key: "title", type: "string", isNullable: false },
+    { key: "author", type: "string", isNullable: false },
+    { key: "category", type: "string", isNullable: false },
+    { key: "status", type: "number", isNullable: false },
+    { key: "isbn", type: "string", isNullable: true },
+    { key: "publisher", type: "string", isNullable: true },
+    { key: "publishedAt", type: "string", isNullable: true },
+    { key: "image", type: "string", isNullable: true },
+    { key: "callSign", type: "string", isNullable: false },
+  ];
+
+  const refineResponse = response => {
+    console.log(response);
+    const [book] = compareExpect("books/:id", [response.data], expectedItem);
+    setBookDetail(book);
+  };
+
+  const displayError = error => {
+    closeModal();
+    setErrorDialog(error, setOpenTitleAndMessage);
+  };
+
+  useEffect(() => {
+    if (id) request(refineResponse, displayError);
+  }, [id]);
+
+  return { bookDetail };
+};
+
+export default useGetBooksIdForStock;

--- a/src/api/stock/useGetStockSearch.js
+++ b/src/api/stock/useGetStockSearch.js
@@ -1,0 +1,46 @@
+import { useEffect } from "react";
+import { setErrorDialog } from "../../data/error";
+import useApi from "../../hook/useApi";
+import useSearch from "../../hook/useSearch";
+import { compareExpect } from "../../util/typeCheck";
+
+const useGetStockSearch = ({ setOpenTitleAndMessage }) => {
+  const { searchParams, setSearchResult, searchResult, setPage } = useSearch();
+  const { request } = useApi("get", "stock/search", {
+    page: searchParams.page - 1,
+    limit: searchParams.limit,
+  });
+
+  const expectedItem = [
+    { key: "bookId", type: "number", isNullable: false },
+    { key: "callSign", type: "string", isNullable: false },
+    { key: "category", type: "string", isNullable: false },
+    { key: "title", type: "string", isNullable: false },
+  ];
+
+  const refineResponse = response => {
+    const items = compareExpect(
+      "stock/search",
+      response.data.items,
+      expectedItem,
+    );
+    const { totalPages } = response.data.meta;
+
+    setSearchResult({
+      lastPage: parseInt(totalPages, 10),
+      list: items,
+    });
+  };
+
+  const displayError = error => {
+    setErrorDialog(error, setOpenTitleAndMessage);
+  };
+
+  useEffect(() => {
+    request(refineResponse, displayError);
+  }, [searchParams]);
+
+  return { ...searchResult, page: searchParams.page, setPage };
+};
+
+export default useGetStockSearch;

--- a/src/api/stock/usePatchStockUpdate.js
+++ b/src/api/stock/usePatchStockUpdate.js
@@ -1,0 +1,30 @@
+import { useEffect, useState } from "react";
+import getErrorMessage from "../../data/error";
+import useApi from "../../hook/useApi";
+
+const usePatchStockUpdate = ({ setOpenTitleAndMessage, addList }) => {
+  const [bookId, setBookId] = useState(undefined);
+  const { request } = useApi("patch", `stock/update`, { id: bookId });
+
+  const onSuccess = () => {
+    setOpenTitleAndMessage("처리되었습니다", "", addList);
+  };
+
+  const onError = error => {
+    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
+    const [title, message] = getErrorMessage(errorCode).split("\r\n");
+    setOpenTitleAndMessage(
+      title,
+      errorCode ? message : `${message}\r\n${error?.message}`,
+    );
+  };
+
+  useEffect(() => {
+    if (bookId !== undefined) {
+      request(onSuccess, onError);
+    }
+  }, [bookId]);
+  return { setBookId };
+};
+
+export default usePatchStockUpdate;

--- a/src/component/bookStock/BookStock.js
+++ b/src/component/bookStock/BookStock.js
@@ -4,7 +4,6 @@ import Tabs from "../utils/Tabs";
 import { managementTabList } from "../../data/tablist";
 import BookStockCheckedList from "./BookStockCheckedList";
 import BookStockNeedToCheckList from "./BookStockNeedToCheckList";
-import "../../css/BookStock.css";
 import BookStockCheckByReadingQR from "./BookStockCheckByReadingQR";
 
 const BookStock = () => {

--- a/src/component/bookStock/BookStock.js
+++ b/src/component/bookStock/BookStock.js
@@ -1,0 +1,19 @@
+import React from "react";
+import Banner from "../utils/Banner";
+import Tabs from "../utils/Tabs";
+import { managementTabList } from "../../data/tablist";
+import "../../css/BookStock.css";
+
+const BookStock = () => {
+  return (
+    <>
+      <Banner img="admin" titleKo="도서 관리" titleEn="BOOK MANAGEMENT" />
+      <Tabs tabList={managementTabList} />
+      <div className="check_stock_box">
+        <button type="button">재고 확인</button>
+      </div>
+    </>
+  );
+};
+
+export default BookStock;

--- a/src/component/bookStock/BookStock.js
+++ b/src/component/bookStock/BookStock.js
@@ -1,17 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import Banner from "../utils/Banner";
 import Tabs from "../utils/Tabs";
 import { managementTabList } from "../../data/tablist";
+import BookStockCheckedList from "./BookStockCheckedList";
+import BookStockNeedToCheckList from "./BookStockNeedToCheckList";
 import "../../css/BookStock.css";
+import BookStockCheckByReadingQR from "./BookStockCheckByReadingQR";
 
 const BookStock = () => {
+  const [checkedList, setCheckedList] = useState([]);
+
+  const addChecked = checked => {
+    setCheckedList([...checkedList, checked]);
+  };
+
   return (
     <>
       <Banner img="admin" titleKo="도서 관리" titleEn="BOOK MANAGEMENT" />
       <Tabs tabList={managementTabList} />
-      <div className="check_stock_box">
-        <button type="button">재고 확인</button>
-      </div>
+      <BookStockCheckByReadingQR addChecked={addChecked} />
+      <BookStockCheckedList checkedList={checkedList} />
+      <BookStockNeedToCheckList />
     </>
   );
 };

--- a/src/component/bookStock/BookStockCheckByReadingQR.js
+++ b/src/component/bookStock/BookStockCheckByReadingQR.js
@@ -1,0 +1,47 @@
+import React, { useCallback, useState } from "react";
+import PropTypes from "prop-types";
+import BarcodeReader from "../utils/BarcodeReader";
+import useModal from "../../hook/useModal";
+import { parseBookIdFromQRLabel } from "../../util/parseBookIdFromQRLabel";
+import BookStockDetailModal from "./BookStockDetailModal";
+
+const BookStockCheckByReadingQR = ({ addChecked }) => {
+  const [bookId, setBookId] = useState(0);
+  const {
+    isOpen: isModalOpen,
+    setOpen: openBookDetailModal,
+    setClose: closeModal,
+    Modal,
+  } = useModal();
+
+  const isReadyToRead = !isModalOpen;
+
+  const toDoAfterRead = useCallback(QRText => {
+    if (isReadyToRead) {
+      const parsedId = parseBookIdFromQRLabel(QRText);
+      setBookId(parsedId);
+      openBookDetailModal();
+    }
+  }, []);
+
+  return (
+    <section>
+      {isReadyToRead ? <BarcodeReader toDoAfterRead={toDoAfterRead} /> : null}
+      {bookId ? (
+        <Modal isOpen={isModalOpen} closeModal={closeModal}>
+          <BookStockDetailModal
+            bookId={bookId}
+            closeModal={closeModal}
+            addChecked={addChecked}
+          />
+        </Modal>
+      ) : null}
+    </section>
+  );
+};
+
+export default BookStockCheckByReadingQR;
+
+BookStockCheckByReadingQR.propTypes = {
+  addChecked: PropTypes.func.isRequired,
+};

--- a/src/component/bookStock/BookStockCheckedList.js
+++ b/src/component/bookStock/BookStockCheckedList.js
@@ -1,0 +1,45 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import InquireBoxTitle from "../utils/InquireBoxTitle";
+import Book from "../../img/admin_icon.svg";
+import InquireBoxBody from "../utils/InquireBoxBody";
+import BookStockCheckedListLine from "./BookStockCheckedListLine";
+import Pagination from "../utils/Pagination";
+import "../../css/BookStockCheckedList.css";
+
+const BookStockCheckedList = ({ checkedList }) => {
+  const [page, setPage] = useState(1);
+
+  const start = (page - 1) * 5;
+  const VisibleList = checkedList.slice(start, start + 5);
+  const lastPage =
+    checkedList.length > 5 ? Math.floor(checkedList.length / 5) + 1 : 0;
+
+  return (
+    <section className="book-stock__checked-list">
+      <InquireBoxTitle
+        Icon={Book}
+        titleKO="확인 완료"
+        titleEN="방금 재고확인한 도서 목록입니다. 새로고침시 유지되지 않으니 조심하세요!"
+      />
+      <InquireBoxBody className="book-stock__checked-list__box">
+        {VisibleList.map(book => (
+          <BookStockCheckedListLine key={book.bookId} book={book} />
+        ))}
+
+        <Pagination
+          page={page}
+          lastPage={lastPage}
+          setPage={setPage}
+          className="book-stock__need-to__pagination"
+        />
+      </InquireBoxBody>
+    </section>
+  );
+};
+
+export default BookStockCheckedList;
+
+BookStockCheckedList.propTypes = {
+  checkedList: PropTypes.arrayOf(PropTypes.shape).isRequired,
+};

--- a/src/component/bookStock/BookStockCheckedListLine.js
+++ b/src/component/bookStock/BookStockCheckedListLine.js
@@ -1,0 +1,21 @@
+import PropTypes from "prop-types";
+import React from "react";
+import InquireBoxItem from "../utils/InquireBoxItem";
+import InquireBoxLine from "../utils/InquireBoxLine";
+
+const BookStockCheckedListLine = ({ book }) => {
+  return (
+    <InquireBoxLine>
+      <InquireBoxItem keyString="bookId" value={book.bookId} />
+      <InquireBoxItem keyString="callSign" value={book.callSign} />
+      <InquireBoxItem keyString="category" value={book.category} />
+      <InquireBoxItem keyString="title" value={book.title} />
+    </InquireBoxLine>
+  );
+};
+
+export default BookStockCheckedListLine;
+
+BookStockCheckedListLine.propTypes = {
+  book: PropTypes.shape.isRequired,
+};

--- a/src/component/bookStock/BookStockDetailModal.js
+++ b/src/component/bookStock/BookStockDetailModal.js
@@ -1,0 +1,70 @@
+import React from "react";
+import PropTypes from "prop-types";
+// import Button from "../utils/Button";
+import useGetBooksIdForStock from "../../api/books/useGetBooksIdForStock";
+import BookDetailView from "../utils/BookDetailView";
+import SpanWithLabel from "../utils/SpanWithLabel";
+import Button from "../utils/Button";
+import useDialog from "../../hook/useDialog";
+import { bookStatus } from "../../data/status";
+import usePatchStockUpdate from "../../api/stock/usePatchStockUpdate";
+
+const BookStockDetailModal = ({ bookId, closeModal, addChecked }) => {
+  const { setOpenTitleAndMessage, Dialog } = useDialog();
+  const { bookDetail: book } = useGetBooksIdForStock({
+    id: bookId,
+    setOpenTitleAndMessage,
+    closeModal,
+  });
+
+  const { setBookId } = usePatchStockUpdate({
+    setOpenTitleAndMessage,
+    addList: () => {
+      addChecked(book);
+      closeModal();
+    },
+  });
+
+  const callUpdate = () => {
+    setBookId(bookId);
+  };
+
+  return (
+    <>
+      {book.bookId ? (
+        <BookDetailView
+          book={book}
+          bookInfoDetailUI={
+            <>
+              <SpanWithLabel labelText="INFO ID" value={book.bookInfoId} />
+              <SpanWithLabel labelText="제목" value={book.title} />
+              <SpanWithLabel labelText="저자" value={book.author} />
+              <SpanWithLabel labelText="카테고리" value={book.category} />
+            </>
+          }
+          bookDetailUI={
+            <>
+              <SpanWithLabel labelText="BOOK ID" value={book.bookId} />
+              <SpanWithLabel labelText="청구기호" value={book.callSign} />
+              <SpanWithLabel
+                labelText="도서 상태"
+                value={bookStatus.find(i => i.code === book.status).string}
+              />
+            </>
+          }
+          bottomUI={<Button onClick={callUpdate} value="업데이트" />}
+        />
+      ) : null}
+
+      <Dialog />
+    </>
+  );
+};
+
+export default BookStockDetailModal;
+
+BookStockDetailModal.propTypes = {
+  bookId: PropTypes.number.isRequired,
+  addChecked: PropTypes.func.isRequired,
+  closeModal: PropTypes.func.isRequired,
+};

--- a/src/component/bookStock/BookStockDetailModal.js
+++ b/src/component/bookStock/BookStockDetailModal.js
@@ -1,6 +1,5 @@
 import React from "react";
 import PropTypes from "prop-types";
-// import Button from "../utils/Button";
 import useGetBooksIdForStock from "../../api/books/useGetBooksIdForStock";
 import BookDetailView from "../utils/BookDetailView";
 import SpanWithLabel from "../utils/SpanWithLabel";
@@ -8,6 +7,7 @@ import Button from "../utils/Button";
 import useDialog from "../../hook/useDialog";
 import { bookStatus } from "../../data/status";
 import usePatchStockUpdate from "../../api/stock/usePatchStockUpdate";
+import "../../css/BookStockDetailModal.css";
 
 const BookStockDetailModal = ({ bookId, closeModal, addChecked }) => {
   const { setOpenTitleAndMessage, Dialog } = useDialog();
@@ -52,7 +52,12 @@ const BookStockDetailModal = ({ bookId, closeModal, addChecked }) => {
               />
             </>
           }
-          bottomUI={<Button onClick={callUpdate} value="업데이트" />}
+          bottomUI={
+            <div className="book-stock__detail-modal__buttons">
+              <Button onClick={callUpdate} value="업데이트" color="red" />
+              <Button onClick={closeModal} value="닫기" />
+            </div>
+          }
         />
       ) : null}
 

--- a/src/component/bookStock/BookStockNeedToCheckList.js
+++ b/src/component/bookStock/BookStockNeedToCheckList.js
@@ -1,0 +1,40 @@
+import React from "react";
+import BookStockNeedToCheckListLine from "./BookStockNeedToCheckListLine";
+import useGetStockSearch from "../../api/stock/useGetStockSearch";
+import InquireBoxTitle from "../utils/InquireBoxTitle";
+import InquireBoxBody from "../utils/InquireBoxBody";
+import Pagination from "../utils/Pagination";
+import Book from "../../img/admin_icon.svg";
+import useDialog from "../../hook/useDialog";
+import "../../css/BookStockNeedToCheckList.css";
+
+const BookStockNeedToCheckList = () => {
+  const { setOpenTitleAndMessage, Dialog } = useDialog();
+  const { page, setPage, lastPage, list } = useGetStockSearch({
+    setOpenTitleAndMessage,
+  });
+
+  return (
+    <section>
+      <InquireBoxTitle
+        Icon={Book}
+        titleKO="확인 필요"
+        titleEN="최근 업데이트되지 않은 책 목록입니다. 분실되지 않았는지 확인해주세요"
+      />
+      <InquireBoxBody className="book-stock__need-to-checked">
+        {list.map(book => (
+          <BookStockNeedToCheckListLine key={book.bookId} book={book} />
+        ))}
+        <Pagination
+          page={page}
+          lastPage={lastPage}
+          setPage={setPage}
+          className="book-stock__need-to__pagination"
+        />
+      </InquireBoxBody>
+      <Dialog />
+    </section>
+  );
+};
+
+export default BookStockNeedToCheckList;

--- a/src/component/bookStock/BookStockNeedToCheckListLine.js
+++ b/src/component/bookStock/BookStockNeedToCheckListLine.js
@@ -1,0 +1,50 @@
+import React from "react";
+import PropTypes from "prop-types";
+import InquireBoxItem from "../utils/InquireBoxItem";
+import InquireBoxLine from "../utils/InquireBoxLine";
+import usePatchBooksUpdate from "../../api/books/usePatchBooksUpdate";
+import useDialog from "../../hook/useDialog";
+
+const BookStockNeedToCheckListLine = ({ book }) => {
+  const {
+    setClose: closeConfirm,
+    Dialog: ConfirmDialog,
+    setOpenConfirm,
+  } = useDialog();
+  const { setChange, Dialog: ResultDialog } = usePatchBooksUpdate({
+    bookTitle: book.title,
+    closeModal: closeConfirm,
+  });
+  const setLostBook = e => {
+    const unFound = e.currentTarget;
+    console.log(unFound, unFound?.id, unFound?.value);
+    setOpenConfirm("분실처리하시겠습니까?", unFound.value, () => {
+      setChange({ bookId: unFound.id, status: 1 });
+    });
+  };
+  return (
+    <InquireBoxLine key={book.bookId}>
+      <ConfirmDialog />
+      <ResultDialog />
+      <InquireBoxItem keyString="bookId" value={book.bookId} />
+      <InquireBoxItem keyString="callSign" value={book.callSign} />
+      <InquireBoxItem keyString="category" value={book.category} />
+      <InquireBoxItem keyString="title" value={book.title} />
+      <button
+        className="book-stock__lost-button"
+        type="button"
+        id={book.bookId}
+        value={book.title}
+        onClick={setLostBook}
+      >
+        분실처리
+      </button>
+    </InquireBoxLine>
+  );
+};
+
+export default BookStockNeedToCheckListLine;
+
+BookStockNeedToCheckListLine.propTypes = {
+  book: PropTypes.shape().isRequired,
+};

--- a/src/component/utils/BookDetailView.js
+++ b/src/component/utils/BookDetailView.js
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+import Image from "./Image";
+import "../../css/BookDetailView.css";
+
+const BookDetailView = ({ book, bookInfoDetailUI, bookDetailUI, bottomUI }) => {
+  return (
+    <div className="book__detail__wrarpper">
+      <p className="book__detail__title">도서정보</p>
+      <div className="book__detail__book-info">
+        <Image
+          className="book__detail__book-cover"
+          src={book.image}
+          alt={book.title}
+        />
+        <div className="book__detail__details">{bookInfoDetailUI}</div>
+      </div>
+      {bookDetailUI ? (
+        <div className="book__detail__book">
+          <p>도서관리정보</p>
+          <div className="book__detail__details">{bookDetailUI}</div>
+        </div>
+      ) : null}
+      {bottomUI}
+    </div>
+  );
+};
+
+export default BookDetailView;
+
+BookDetailView.propTypes = {
+  book: PropTypes.shape().isRequired,
+  bookInfoDetailUI: PropTypes.node.isRequired,
+  bookDetailUI: PropTypes.node,
+  bottomUI: PropTypes.node.isRequired,
+};
+
+BookDetailView.defaultProps = {
+  bookDetailUI: undefined,
+};

--- a/src/component/utils/InquireBoxBody.js
+++ b/src/component/utils/InquireBoxBody.js
@@ -1,0 +1,14 @@
+import React from "react";
+import PropTypes from "prop-types";
+import "../../css/InquireBoxBody.css";
+
+const InquireBoxBody = ({ children, className }) => {
+  return <div className={`inquire-body__wrapper ${className}`}>{children}</div>;
+};
+
+export default InquireBoxBody;
+
+InquireBoxBody.propTypes = {
+  children: PropTypes.node.isRequired,
+  className: PropTypes.string.isRequired,
+};

--- a/src/component/utils/InquireBoxItem.js
+++ b/src/component/utils/InquireBoxItem.js
@@ -1,0 +1,18 @@
+import PropTypes from "prop-types";
+import React from "react";
+import "../../css/InquireBoxItem.css";
+
+const InquireBoxItem = ({ keyString, value }) => {
+  return (
+    <span key={keyString} className={`inquire-item__${keyString}`}>
+      {value}
+    </span>
+  );
+};
+
+export default InquireBoxItem;
+
+InquireBoxItem.propTypes = {
+  keyString: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.number, PropTypes.string]).isRequired,
+};

--- a/src/component/utils/InquireBoxLine.js
+++ b/src/component/utils/InquireBoxLine.js
@@ -1,0 +1,12 @@
+import PropTypes from "prop-types";
+import React from "react";
+import "../../css/InquireBoxLine.css";
+
+const InquireBoxLine = ({ children }) => {
+  return <div className="inquire-line__wrapper">{children}</div>;
+};
+
+export default InquireBoxLine;
+InquireBoxLine.propTypes = {
+  children: PropTypes.node.isRequired,
+};

--- a/src/component/utils/Pagination.js
+++ b/src/component/utils/Pagination.js
@@ -7,6 +7,7 @@ import ArrRightDouble from "../../img/arrow_right_black_double.svg";
 import "../../css/Pagination.css";
 
 const Pagination = ({
+  className,
   page,
   setPage,
   lastPage,
@@ -45,7 +46,7 @@ const Pagination = ({
   };
 
   return (
-    <div className="pagination">
+    <div className={`pagination ${className}`}>
       {/* 왼쪽으로 넘기기 버튼 */}
       <div className="pagination__page-ranges">
         {isPrevAvailable && (
@@ -128,6 +129,7 @@ const Pagination = ({
 export default Pagination;
 
 Pagination.propTypes = {
+  className: PropTypes.string,
   page: PropTypes.number.isRequired,
   setPage: PropTypes.func.isRequired,
   lastPage: PropTypes.number.isRequired,
@@ -140,6 +142,7 @@ Pagination.propTypes = {
 };
 
 Pagination.defaultProps = {
+  className: "",
   isReplaceUrl: false,
   scrollRef: undefined,
   count: 5,

--- a/src/component/utils/SpanWithLabel.js
+++ b/src/component/utils/SpanWithLabel.js
@@ -1,0 +1,39 @@
+import React from "react";
+import PropTypes from "prop-types";
+import "../../css/SpanWithLabel.css";
+
+const SpanWithLabel = ({ wrapperClassName, labelText, value, align }) => {
+  const alignType = () => {
+    const candidate = ["horizontal", "vertical"];
+    if (candidate.includes(align)) return align;
+    return "horizontal";
+  };
+  return (
+    <div className={`span__wrapper ${alignType()} ${wrapperClassName} `}>
+      {labelText?.length > 0 && (
+        <label className="span__label" htmlFor="text">
+          {labelText}
+        </label>
+      )}
+      <span id="text" className="span__text">
+        {value}
+      </span>
+    </div>
+  );
+};
+
+export default SpanWithLabel;
+
+SpanWithLabel.propTypes = {
+  wrapperClassName: PropTypes.string,
+  labelText: PropTypes.string,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+  align: PropTypes.string,
+};
+
+SpanWithLabel.defaultProps = {
+  wrapperClassName: "",
+  labelText: "",
+  align: "",
+  value: "",
+};

--- a/src/css/BookDetailView.css
+++ b/src/css/BookDetailView.css
@@ -1,0 +1,77 @@
+.book__detail__wrarpper {
+  min-width: 30rem;
+  font-size: 1.8rem;
+  font-weight: bold;
+  color: #545454;
+  padding: 0 8rem 5rem;
+}
+
+.book__detail__title {
+  font-size: 2.8rem;
+}
+
+.book__detail__book-info {
+  margin-top: 3rem;
+}
+.book__detail__book-info,
+.book__detail__book {
+  display: flex;
+  padding: 2rem 0;
+  border-top: solid #a4a4a4 0.1rem;
+}
+
+.book__detail__book-info > img,
+.book__detail__book > p {
+  width: 20%;
+  margin: auto;
+  text-align: center;
+}
+
+.book__detail__details {
+  width: 70%;
+  margin: auto;
+}
+.book__detail__details > * {
+  margin-bottom: 1.1rem;
+  white-space: pre-wrap;
+}
+.book__detail__book {
+  display: flex;
+}
+
+.book__detail__message {
+  white-space: pre;
+  font-weight: normal;
+  color: #e63737;
+  word-break: break-all;
+  text-align: center;
+}
+
+.book__detail__buttons {
+  display: flex;
+  justify-content: right;
+}
+
+.book__detail__button {
+  margin-left: 2rem;
+}
+
+@media screen and (max-width: 767px) {
+  .book__detail__wrarpper {
+    padding: 0 2rem 4rem;
+  }
+  .book__detail__book-info,
+  .book__detail__book {
+    flex-direction: column;
+  }
+
+  .book__detail__book-info > img,
+  .book__detail__book > p {
+    width: 30%;
+    margin: 0 auto 2rem;
+  }
+  .book__detail__details {
+    margin: 0;
+    width: 100%;
+  }
+}

--- a/src/css/BookStock.css
+++ b/src/css/BookStock.css
@@ -1,0 +1,5 @@
+.check_stock_box {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}

--- a/src/css/BookStock.css
+++ b/src/css/BookStock.css
@@ -1,5 +1,0 @@
-.check_stock_box {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}

--- a/src/css/BookStockCheckedList.css
+++ b/src/css/BookStockCheckedList.css
@@ -1,0 +1,6 @@
+.book-stock__checked-list {
+  margin-top: 8rem;
+}
+.book-stock__checked-list__box {
+  margin-bottom: 8rem;
+}

--- a/src/css/BookStockDetailModal.css
+++ b/src/css/BookStockDetailModal.css
@@ -1,0 +1,8 @@
+.book-stock__detail-modal__buttons {
+  display: flex;
+  justify-content: end;
+}
+
+.book-stock__detail-modal__buttons > button {
+  margin-left: 2rem;
+}

--- a/src/css/BookStockNeedToCheckList.css
+++ b/src/css/BookStockNeedToCheckList.css
@@ -1,0 +1,39 @@
+.inquire-line__wrapper > span {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  text-align: center;
+}
+
+.inquire-item__bookId {
+  font-weight: bold;
+  flex: 0 0 4rem;
+}
+
+.inquire-item__callSign {
+  flex: 0 0 10rem;
+  font-weight: bold;
+}
+.inquire-item__category {
+  flex: 0 0 12rem;
+}
+
+.inquire-item__title {
+  flex: 1 0 6rem;
+}
+
+.book-stock__need-to__pagination {
+  padding: 2rem 0 4rem;
+}
+.book-stock__lost-button {
+  font-size: 1.4rem;
+  color: #a4a4a4;
+  background-color: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+@media screen and (max-width: 767px) {
+  .inquire-item__category {
+    display: none;
+  }
+}

--- a/src/css/InquireBoxBody.css
+++ b/src/css/InquireBoxBody.css
@@ -1,0 +1,18 @@
+.inquire-body__wrapper {
+  display: flex;
+  flex-direction: column;
+  max-width: 120rem;
+  min-width: 36rem;
+  background-color: #e8e8e8;
+  color: #545454;
+  margin: -5rem auto 14rem auto;
+  border-bottom-left-radius: 6.5rem;
+  border-bottom-right-radius: 6.5rem;
+  padding: 7rem 0 0;
+}
+
+@media screen and(max-width: 767px) {
+  .inquire-body__wrapper {
+    padding: 5rem 0 0;
+  }
+}

--- a/src/css/InquireBoxItem.css
+++ b/src/css/InquireBoxItem.css
@@ -1,0 +1,3 @@
+.inquire-item__wrapper:not(:first-of-type) {
+  border-top: solid 0.1rem #a4a4a4;
+}

--- a/src/css/InquireBoxLine.css
+++ b/src/css/InquireBoxLine.css
@@ -1,0 +1,23 @@
+.inquire-line__wrapper {
+  display: flex;
+  height: 4rem;
+  padding: 2rem 2rem;
+}
+
+.inquire-line__wrapper:not(:first-of-type) {
+  border-top: solid 0.1rem #a4a4a4;
+}
+
+.inquire-line__wrapper > * {
+  font-size: 1.4rem;
+  margin: 1rem 0.5rem;
+}
+@media screen and (max-width: 767px) {
+  .inquire-line__wrapper {
+    height: 3rem;
+    padding: 1rem 1rem;
+  }
+  .inquire-line__wrapper > * {
+    margin: 0 0.3rem;
+  }
+}

--- a/src/css/SpanWithLabel.css
+++ b/src/css/SpanWithLabel.css
@@ -1,0 +1,16 @@
+.span__wrapper.horizontal {
+  display: flex;
+  align-items: center;
+  justify-items: center;
+}
+
+.span__label {
+  width: 15rem;
+  flex-shrink: 0;
+}
+.span__text {
+  font-size: 1.8rem;
+  font-weight: normal;
+  padding: 0;
+  flex-grow: 1;
+}

--- a/src/data/tablist.js
+++ b/src/data/tablist.js
@@ -3,6 +3,7 @@ export const managementTabList = [
   { name: "도서등록", link: "/addbook" },
   { name: "도서관리", link: "/book" },
   { name: "리뷰관리", link: "/review" },
+  { name: "재고관리", link: "/stock" },
 ];
 
 export const rentTabList = [

--- a/src/hook/useDialog.js
+++ b/src/hook/useDialog.js
@@ -36,6 +36,22 @@ const useDialog = () => {
     config.afterClose();
   };
 
+  const setOpenConfirm = (title, message, confirmCallback = () => {}) => {
+    setConfig({
+      ...defaultConfig,
+      title,
+      message,
+      firstButton: {
+        ...defaultConfig.firstButton,
+        onClick: () => {
+          confirmCallback();
+          setClose();
+        },
+      },
+    });
+    setOpen();
+  };
+
   const setOpenTitleAndMessage = (title, message, afterClose = () => {}) => {
     setConfig({
       ...defaultConfig,
@@ -91,6 +107,7 @@ const useDialog = () => {
     defaultConfig, // for reset
     setConfig,
     setOpenTitleAndMessage,
+    setOpenConfirm,
     Dialog,
   };
 };

--- a/src/util/parseBookIdFromQRLabel.js
+++ b/src/util/parseBookIdFromQRLabel.js
@@ -1,0 +1,4 @@
+// eslint-disable-next-line import/prefer-default-export
+export const parseBookIdFromQRLabel = QRText => {
+  return parseInt(QRText.split(" ")[0], 10);
+};


### PR DESCRIPTION

## 요약
도서 분실확인용 재고관리 페이지 추가
https://github.com/orgs/jiphyeonjeon-42/discussions/1  에서 논의했던 기능을 페이지로 구현

### 재고관리 분실확인 시나리오
- 비치되어 있는 책의 라벨 QR 코드 인식
- 라벨 내 bookId 기준 책정보 모달 확인
- 실물 책과 모달창이 일치하면 업데이트 버튼 클릭
- 확인 완료 목록에 추가됨 (새로고침시 사라짐)
- 비치된 책을 모두 확인했는데도 확인 필요 목록에서 남은 책은 분실처리


### 기능 상세
- QR 리더기로 인식한 책정보 모달
- 업데이트 요청 성공한 책 목록 
- 업데이트되지 않은 목록
- 분실처리

## preview
### 재고관리 페이지 PC
<img width="453" alt="image" src="https://user-images.githubusercontent.com/74622889/223635287-d997869f-12e7-43d5-b879-3ed51227d744.png"><img width="921" alt="image" src="https://user-images.githubusercontent.com/74622889/223642740-7e0e4dd3-24e5-42dc-a1bf-a9790c86d927.png">


### 재고관리 페이지 mobile
<img width="504" alt="image" src="https://user-images.githubusercontent.com/74622889/223638840-f13bb63d-bc4f-49c3-af7f-a030d6461e0c.png"><img width="501" alt="image" src="https://user-images.githubusercontent.com/74622889/223643433-db29f8c5-046d-41e5-960c-f8bc1ad09d13.png">
