### PR TITLE
HOTFIX: 만우절 페이지 전자도서관 링크 수정

### DIFF
--- a/src/component/eLibraryIn42Box/EventPage.jsx
+++ b/src/component/eLibraryIn42Box/EventPage.jsx
@@ -8,7 +8,7 @@ import "../../css/ELibraryIn42Box.css";
 
 const linkList = {
   BOX: "https://42box.github.io/front-end/",
-  ELIBRARY: "https://42seoul.dkyobobook.co.kr/",
+  ELIBRARY: "https://42seoul.dkyobobook.co.kr/main.ink/",
   HANE24: "https://24hoursarenotenough.42seoul.kr/",
   CODE80000: "https://80000coding.oopy.io/",
   WHERE42: "https://www.where42.kr",


### PR DESCRIPTION
## 요약
만우절 페이지의 iframe 에서 전자도서관이 제대로 로드되지 않는 문제 해결했습니다. 

 
### 기타
- 다른 도메인으로 배포해본 결과 제대로 작동되는 점 확인했습니다. 
https://test.42jip.com/41
<img width="560" alt="image" src="https://user-images.githubusercontent.com/74622889/228793581-5888e678-0c5e-4749-8d7d-55fa8f4117e7.png">
