### PR TITLE
ENV: git action workflow 버전 업데이트

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,13 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout source code
-        uses: actions/checkout@master
+        uses: actions/checkout@v3
 
       - name: Cache node modules  # node modules 캐싱
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.OS }}-master-build-${{ hashFiles('**/package-lock.json') }}


### PR DESCRIPTION
## 요약
git action에 활용되는 workflow의 버전을 최신버전으로 수정했습니다. 

### 문제상황
git action이 제대로 진행되지 않던 문제 
![image](https://user-images.githubusercontent.com/74622889/230000283-80e8e802-55a8-417c-a552-d7ba6c3f2b81.png)

### 원인
- 우분투 버전 18.04를 더이상 지원하지 않았음
https://github.com/actions/runner-images/issues/6002

### 변경사항
- 18.04 -> latest으로 변경, 최신으로 항상 유지되도록 수정함
- 기타 checkout과 cache action도 최신 버전 (v3)으로 변경함
https://github.com/actions/checkout
https://github.com/actions/cache

### 기타 검토한 내용
- 레포지토리 fork 후 action이 제대로 돌아가는 점 확인했습니다 (deploy는 aws 설정 미적용으로 실패지만 직전까지는 진행됩니다)
<img width="1072" alt="image" src="https://user-images.githubusercontent.com/74622889/230001957-b8942fbe-6396-43af-a867-374be81a4c5f.png">
  - checkout/ cache 버전도 변경 후 관련 오류가 없어지는 점 확인했습니다. 
    <img width="903" alt="image" src="https://user-images.githubusercontent.com/74622889/230002600-811285bf-4692-4b7f-bc12-ad0bdd939526.png">
