### PR TITLE
fix: 로그인 관련 리다이렉트 시 히스토리 스택에서 제외

### DIFF
--- a/src/LimitedRoute.jsx
+++ b/src/LimitedRoute.jsx
@@ -12,10 +12,10 @@ const LimitedRoute = ({ isLoginOnly, isAdminOnly, isLogoutOnly }) => {
     return <NotFound />;
   }
   if (isLoginOnly && !user?.isLogin) {
-    return <Navigate to="/login" />;
+    return <Navigate to="/login" replace={true} />;
   }
   if (isLogoutOnly && user?.isLogin) {
-    return <Navigate to="/" />;
+    return <Navigate to="/" replace={true} />;
   }
   return <Outlet />;
 };

--- a/src/api/auth/usePostAuthLogin.js
+++ b/src/api/auth/usePostAuthLogin.js
@@ -24,7 +24,7 @@ const usePostAuthLogin = () => {
 
   const navigate = useNavigate();
   const onSuccess = () => {
-    navigate("/auth");
+    navigate("/auth", { replace: true });
   };
 
   const onError = error => {

--- a/src/component/login/Auth.jsx
+++ b/src/component/login/Auth.jsx
@@ -9,6 +9,6 @@ const Auth = () => {
     getMe();
   }, []);
 
-  return <Navigate to="/" />;
+  return <Navigate to="/" replace={true} />;
 };
 export default Auth;

--- a/src/component/login/Logout.jsx
+++ b/src/component/login/Logout.jsx
@@ -16,7 +16,7 @@ const Logout = () => {
 
   return (
     <>
-      <Navigate to="/" />
+      <Navigate to="/" replace={true} />
     </>
   );
 };


### PR DESCRIPTION
## 요약
로그인 등 권한 확인후 리다이렉트시 히스토리 기록을 남기지 않도록 수정합니다. 

### 문제상황
모바일 환경에서는 뒤로가기를 연속으로 하면 브라우저 창이 닫아져야 함
집현전 홈페이지는 뒤로가기로 창닫기가 제대로 작동하지 않던 문제

![Apr-05-2023 20-46-02](https://user-images.githubusercontent.com/74622889/230073116-2ee796bd-f8f5-4c35-8804-00cdc8f21ebb.gif)

### 원인
로그인 페이지를 거친 후 남은 히스토리 내역 + 이미 로그인된 상태에서 다시 로그인 접근시 메인으로 리다이렉트 = 뒤로가기 감옥

### 변경사항
로그인 관련 리다이렉트 시 히스토리 스택에서 제외

### 기타 고려사항
- 최초 도달시의 기록이 하나 남아서 1회 한정 뒤로가기에 영향을 받지 않습니다.

### preview
![Apr-05-2023 20-47-38](https://user-images.githubusercontent.com/74622889/230073136-0a19557b-8d81-4f2f-9403-6a2b46689d85.gif)


364