### PR TITLE
refactor: DB관리 탭 분리

### DIFF
--- a/src/component/addbook/AddBook.jsx
+++ b/src/component/addbook/AddBook.jsx
@@ -9,7 +9,7 @@ import Banner from "../utils/Banner";
 import BarcodeReader from "../utils/BarcodeReader";
 import InquireBoxTitle from "../utils/InquireBoxTitle";
 
-import { managementTabList } from "../../data/tablist";
+import { bookManagementTabList } from "../../data/tablist";
 import Book from "../../img/admin_icon.svg";
 import "../../css/AddBook.css";
 
@@ -40,7 +40,7 @@ const AddBook = () => {
   return (
     <main>
       <Banner img="admin" titleKo="도서 신규 등록" titleEn="ADD BOOK" />
-      <Tabs tabList={managementTabList} />
+      <Tabs tabList={bookManagementTabList} />
       <section className="add-book__wrapper">
         {isUsingBarcodeReader && (
           <BarcodeReader toDoAfterRead={toDoAfterRead} />

--- a/src/component/bookManagement/BookManagement.jsx
+++ b/src/component/bookManagement/BookManagement.jsx
@@ -4,7 +4,7 @@ import BookManagementCartToPrint from "./BookManagementCartToPrint";
 import BookManagementBooksList from "./BookManagementBooksList";
 import Tabs from "../utils/Tabs";
 import Banner from "../utils/Banner";
-import { managementTabList } from "../../data/tablist";
+import { bookManagementTabList } from "../../data/tablist";
 
 const BookManagement = () => {
   const [printList, setPrintList] = useState([]);
@@ -33,7 +33,7 @@ const BookManagement = () => {
     <main>
       <Dialog />
       <Banner img="admin" titleKo="도서 관리" titleEn="BOOK MANAGEMENT" />
-      <Tabs tabList={managementTabList} />
+      <Tabs tabList={bookManagementTabList} />
       <BookManagementBooksList
         page={page}
         setPage={setPage}

--- a/src/component/bookStock/BookStock.jsx
+++ b/src/component/bookStock/BookStock.jsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import Banner from "../utils/Banner";
 import Tabs from "../utils/Tabs";
-import { managementTabList } from "../../data/tablist";
+import { bookManagementTabList } from "../../data/tablist";
 import BookStockCheckedList from "./BookStockCheckedList";
 import BookStockNeedToCheckList from "./BookStockNeedToCheckList";
 import BookStockCheckByReadingQR from "./BookStockCheckByReadingQR";
@@ -16,7 +16,7 @@ const BookStock = () => {
   return (
     <>
       <Banner img="admin" titleKo="도서 관리" titleEn="BOOK MANAGEMENT" />
-      <Tabs tabList={managementTabList} />
+      <Tabs tabList={bookManagementTabList} />
       <BookStockCheckByReadingQR addChecked={addChecked} />
       <BookStockCheckedList checkedList={checkedList} />
       <BookStockNeedToCheckList />

--- a/src/component/reviewManagement/ReviewManagement.jsx
+++ b/src/component/reviewManagement/ReviewManagement.jsx
@@ -3,7 +3,7 @@ import useGetReviews from "../../api/reviews/useGetReviews";
 import Banner from "../utils/Banner";
 import Tabs from "../utils/Tabs";
 import Management from "../utils/Management";
-import { managementTabList } from "../../data/tablist";
+import { otherManagementTabList } from "../../data/tablist";
 import ReviewManagementList from "./ReviewManagementList";
 import Filter from "../utils/Filter";
 
@@ -32,7 +32,7 @@ const ReviewManagement = () => {
     <main>
       <Dialog />
       <Banner img="admin" titleKo="리뷰 관리" titleEn="REVIEW MANAGEMENT" />
-      <Tabs tabList={managementTabList} />
+      <Tabs tabList={otherManagementTabList} />
       <Management
         searchBarPlaceHolder="도서명이나 닉네임을 검색하세요"
         setQuery={setQuery}

--- a/src/component/userManagement/UserManagement.jsx
+++ b/src/component/userManagement/UserManagement.jsx
@@ -9,7 +9,7 @@ import Modal from "../utils/Modal";
 import ModalHeader from "../utils/ModalHeader";
 import UserDetailInfo from "./UserDetailInfo";
 
-import { managementTabList } from "../../data/tablist";
+import { userManagementTabList } from "../../data/tablist";
 import useGetUsersSearch from "../../api/users/useGetUsersSearch";
 import "../../css/UserManagement.css";
 
@@ -26,7 +26,7 @@ const UserManagement = () => {
   return (
     <main>
       <Banner img="admin" titleKo="유저 관리" titleEn="USER MANAGEMENT" />
-      <Tabs tabList={managementTabList} />
+      <Tabs tabList={userManagementTabList} />
       <section className="user-management-body">
         <div className="user-management-search">
           <SearchBar

--- a/src/data/headerMenu.js
+++ b/src/data/headerMenu.js
@@ -60,9 +60,23 @@ export const adminLnbMenu = [
   },
   {
     mobileImg: DB,
-    imgAlt: "db",
+    imgAlt: "user",
     linkTo: "/user",
-    text: "DB관리",
+    text: "유저관리",
+    idClassName: "db",
+  },
+  {
+    mobileImg: DB,
+    imgAlt: "book",
+    linkTo: "/book",
+    text: "도서관리",
+    idClassName: "db",
+  },
+  {
+    mobileImg: DB,
+    imgAlt: "other_db",
+    linkTo: "/review",
+    text: "추가기능관리",
     idClassName: "db",
   },
 ];

--- a/src/data/tablist.js
+++ b/src/data/tablist.js
@@ -1,10 +1,16 @@
-export const managementTabList = [
+export const userManagementTabList = [
   { name: "유저관리", link: "/user" },
+]
+
+export const bookManagementTabList = [
   { name: "도서등록", link: "/addbook" },
   { name: "도서관리", link: "/book" },
-  { name: "리뷰관리", link: "/review" },
   { name: "재고관리", link: "/stock" },
-];
+]
+
+export const otherManagementTabList =[
+  { name: "리뷰관리", link: "/review" },
+]
 
 export const rentTabList = [
   { name: "대출", link: "/rent" },


### PR DESCRIPTION
## 요약
DB 관리 페이지에 과도하게 몰린 탭을 분산시킵니다.

### 현재 탭
대출/반납 > 대출, 예약대출, 반납, 전체기록
DB 관리 > 유저관리, 도서등록, 도서관리, 리뷰관리, 재고관리

- 태그 관리가 추가될 경우 6~7개가 되어야 함 
- 5개인 현재도 너무 복잡함

<img width="400" alt="image" src="https://user-images.githubusercontent.com/74622889/230074709-f0b7faaa-2736-4a8d-915f-39eb154ad1f7.png">
<img width="376" alt="image" src="https://user-images.githubusercontent.com/74622889/230078135-4c67a099-ca8f-4f25-b66f-7e1813dbbba8.png">
<img width="125" alt="image" src="https://user-images.githubusercontent.com/74622889/230078217-6cbe2a64-0eb9-4075-9dad-d80128ce13d1.png">

### 개선안
대출/반납 > 대출, 예약대출, 반납, 전체기록
유저관리
도서관리 > 도서등록, 도서관리, 재고관리
추가기능관리 > 리뷰관리, 도서별태그(추가예정), 태그머지(추가예정)
<img width="388" alt="image" src="https://user-images.githubusercontent.com/74622889/230077965-71ee58ff-622a-4ce5-a51e-956c9c107a0d.png">
<img width="388" alt="image" src="https://user-images.githubusercontent.com/74622889/230079408-120abeae-3093-46e7-80f7-c1da7b4f0b99.png">
<img width="126" alt="image" src="https://user-images.githubusercontent.com/74622889/230079313-00fa2c83-13b7-4515-8a6f-287c68873f50.png">




### 기타 논의사항
현재 초안은 태그기능 UI 논의과정에서 정리된 내용을 바탕으로 하고 있습니다. 
구현 후 확인해보니 탭 대신 헤더 메뉴가 복잡해진 느낌이 듭니다
메뉴구성 관련 다른 의견이 있으시면 편하게 말씀주세요! 
