### PR TITLE
build: @types 패키지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "eslint-plugin-react": "^7.24.0",
     "ga-gtag": "^1.1.1",
     "prop-types": "^15.7.2",
-    "qs": "^6.10.5",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.3.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     ]
   },
   "devDependencies": {
+    "@types/react": "^18.0.37",
+    "@types/react-dom": "^18.0.11",
+    "@types/react-router-dom": "^5.3.3",
     "eslint-config-prettier": "^8.0.0",
     "eslint-plugin-prettier": "^3.4.0",
     "prettier": "2.3.2"


### PR DESCRIPTION
# 개요

- fixes #413

## 내용

- 사용하지 않던 `qs` 패키지를 제거했습니다.
- [react](https://www.npmjs.com/package/@types/react), [react-dom](https://www.npmjs.com/package/@types/react-dom) 라이브러리는 [flow](https://flow.org)로 작성되었기 때문에 별개의 패키지로 타입스크립트 타입을 제공하고 있습니다. 해당 타입 패키지를 추가했습니다.
