### PR TITLE
fix: 도서검색시 특수문자 인코딩

### DIFF
--- a/src/component/utils/SearchBar.tsx
+++ b/src/component/utils/SearchBar.tsx
@@ -40,7 +40,8 @@ const SearchBar = ({
 
   const onSubmit = event => {
     event.preventDefault();
-    if (isNavigate) navigate(`/search?search=${searchWord}`);
+    const encodedSearchWord = encodeURIComponent(searchWord);
+    if (isNavigate) navigate(`/search?search=${encodedSearchWord}`);
   };
 
   useEffect(() => {


### PR DESCRIPTION
# 개요

- fixes #428 

![image](https://user-images.githubusercontent.com/54838975/234164888-f9913782-de76-4af4-a67d-16ef4e5ca352.png)

도서 검색시 [encodeURIComponent](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent)을 사용해 특수문자를 인코딩합니다. 

인코딩시 URI: `http://localhost:4242/search?search=c%2B%2B&page=1`