### PR TITLE
fix: 메인 페이지 이미지가 지나치게 큼

### DIFF
--- a/src/component/main/MainNewBook.tsx
+++ b/src/component/main/MainNewBook.tsx
@@ -18,8 +18,8 @@ const MainNewBook = ({ book, bookWidth }: Props) => {
     >
       <Link to={`/info/${book.id}`} state={{ bread: "신간 도서" }}>
         <Image
-          width={`${bookWidth}`}
-          height={`${bookWidth * 1.5}`}
+          width={bookWidth}
+          height={bookWidth * 1.5}
           src={book.image}
           alt="new"
         />

--- a/src/component/utils/Image.tsx
+++ b/src/component/utils/Image.tsx
@@ -1,7 +1,7 @@
 import { HTMLProps, useState } from "react";
 import fallback from "../../img/image_onerror.svg";
 
-type Size = number | `${number}px`;
+type Size = number;
 type Props = HTMLProps<HTMLImageElement> & { width?: Size; height?: Size };
 
 const Image = ({ src, alt, width, height, ...props }: Props) => {

--- a/src/component/utils/Image.tsx
+++ b/src/component/utils/Image.tsx
@@ -1,13 +1,10 @@
-import { useRef, useEffect, HTMLProps, useState } from "react";
+import { HTMLProps, useState } from "react";
 import fallback from "../../img/image_onerror.svg";
 
-const Image = ({
-  src,
-  alt,
-  width,
-  height,
-  ...props
-}: HTMLProps<HTMLImageElement>) => {
+type Size = number | `${number}px`;
+type Props = HTMLProps<HTMLImageElement> & { width?: Size; height?: Size };
+
+const Image = ({ src, alt, width, height, ...props }: Props) => {
   const [error, setError] = useState(false);
   return (
     <img


### PR DESCRIPTION
# 개요

- fixes #435 

| 이전 | 이후 |
|--------|--------|
| ![전][전] | ![후][후] |

[전]: https://github.com/jiphyeonjeon-42/frontend/assets/54838975/c678b9fd-5db5-4a93-b9c6-fc68aa39a307
[후]: https://github.com/jiphyeonjeon-42/frontend/assets/54838975/2c45f80e-b2d7-463e-a7c4-e093622398ee

- `Image` 컴포넌트의 `width`, `height` 타입을 엄격하게 변경했습니다 (숫자와 `${숫자}px`만 허용)
- `MainNewBook`의 크기 속성을 문자열에서 숫자로 변경했습니다
