### PR TITLE
fix: 바코드리더 deviceId undefined 오류 해결

### DIFF
--- a/src/component/utils/BarcodeReader.tsx
+++ b/src/component/utils/BarcodeReader.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 const BarcodeReader = ({ toDoAfterRead, wrapperClassName = "" }: Props) => {
   const [deviceList, setDeviceList] = useState<MediaDeviceInfo[]>([]);
-  const [selectedDevice, setSelectedDevice] = useState(deviceList[0].deviceId);
+  const [selectedDevice, setSelectedDevice] = useState(deviceList[0]?.deviceId);
   const videoRef = useRef(null);
   const codeReader = new BrowserMultiFormatReader();
 


### PR DESCRIPTION
# 개요
deviceId 속성이 undefined로 페이지가 터지는 문제 해결

### 변경사항
99877cd568eca9ba2ef5c968a5534c6f214cdd69 커밋에서 빠진 옵셔널체이닝 다시 추가

- fixes #466
