### PR TITLE
refactor: 다이얼로그를 전역으로 관리

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import BookStock from "./component/bookStock/BookStock";
 import ELibraryIn42Box from "./component/eLibraryIn42Box/EventPage";
 import SuperTagManagement from "./component/superTag/SuperTagManagement";
 import SubTagManagement from "./component/subTag/SubTagManagement";
+import Portals from "./component/utils/Portals";
 import "./asset/css/reset.css";
 
 function App() {
@@ -49,6 +50,7 @@ function App() {
   return (
     <BrowserRouter>
       <div id="portal" />
+      <Portals />
       <Header />
       <MobileHeader />
       <Routes>

--- a/src/api/books/useGetBooksId.ts
+++ b/src/api/books/useGetBooksId.ts
@@ -10,7 +10,7 @@ type Props = {
 
 export const useGetBooksId = ({ setSelectedBooks, closeModal }: Props) => {
   const [bookId, setBookId] = useState<string>();
-  const { request, Dialog } = useApi("get", `books/${bookId}`);
+  const { request } = useApi("get", `books/${bookId}`);
 
   const expectedItem = [
     { key: "id", type: "number", isNullable: false },
@@ -31,5 +31,5 @@ export const useGetBooksId = ({ setSelectedBooks, closeModal }: Props) => {
     if (bookId) request(refineResponse);
   }, [bookId]);
 
-  return { setBookId, Dialog };
+  return { setBookId };
 };

--- a/src/api/books/useGetBooksIdForStock.ts
+++ b/src/api/books/useGetBooksIdForStock.ts
@@ -1,20 +1,15 @@
 import { useState, useEffect } from "react";
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { compareExpect } from "../../util/typeCheck";
 import { Book } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   id: number;
   closeModal: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
-export const useGetBooksIdForStock = ({
-  id,
-  closeModal,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const useGetBooksIdForStock = ({ id, closeModal }: Props) => {
   const [bookDetail, setBookDetail] = useState<Book>();
   const { request } = useApi("get", `books/${id}`);
 
@@ -33,14 +28,14 @@ export const useGetBooksIdForStock = ({
   ];
 
   const refineResponse = (response: any) => {
-    console.log(response);
     const [book] = compareExpect("books/:id", [response.data], expectedItem);
     setBookDetail(book);
   };
 
+  const { addErrorDialog } = useNewDialog();
+
   const displayError = (error: any) => {
-    closeModal();
-    setErrorDialog(error, setOpenTitleAndMessage);
+    addErrorDialog(error, closeModal);
   };
 
   useEffect(() => {

--- a/src/api/books/useGetBooksInfoId.ts
+++ b/src/api/books/useGetBooksInfoId.ts
@@ -1,20 +1,15 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import getErrorMessage from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { BookInfo } from "../../type";
 import { compareExpect } from "../../util/typeCheck";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Pros = {
   id: string;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose: () => void,
-  ) => void;
 };
 
-export const useGetBooksInfoId = ({ id, setOpenTitleAndMessage }: Pros) => {
+export const useGetBooksInfoId = ({ id }: Pros) => {
   const [bookDetailInfo, setBookDetailInfo] = useState<BookInfo>();
   const navigate = useNavigate();
 
@@ -51,21 +46,18 @@ export const useGetBooksInfoId = ({ id, setOpenTitleAndMessage }: Pros) => {
     setBookDetailInfo(bookInfo);
   };
 
-  const displayError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
+  const { addErrorDialog } = useNewDialog();
 
-    const afterClose = () => {
+  const displayError = (error: any) => {
+    const errorCode = error?.response?.data?.errorCode;
+    const redirectIfCode304 = () => {
       if (errorCode === 304) {
         navigate("/search");
         window.scrollTo(0, 0);
       }
     };
-    setOpenTitleAndMessage(
-      title,
-      errorCode ? message : `${message}\r\n${error?.message}`,
-      afterClose,
-    );
+
+    addErrorDialog(error, redirectIfCode304);
   };
 
   useEffect(() => {

--- a/src/api/books/useGetBooksInfoNew.ts
+++ b/src/api/books/useGetBooksInfoNew.ts
@@ -1,14 +1,9 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
 import { compareExpect } from "../../util/typeCheck";
 import { Book } from "../../type";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-export const useGetBooksInfoNew = ({ setOpenTitleAndMessage }: Props) => {
+export const useGetBooksInfoNew = () => {
   const [bookList, setBookList] = useState<Book[]>([]);
 
   const { request } = useApi("get", "books/info/", {
@@ -32,13 +27,7 @@ export const useGetBooksInfoNew = ({ setOpenTitleAndMessage }: Props) => {
     setBookList(books);
   };
 
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(title, message || error.message);
-  };
-
-  useEffect(() => request(refineResponse, onError), []);
+  useEffect(() => request(refineResponse), []);
 
   return { bookList };
 };

--- a/src/api/books/useGetBooksInfoPopular.ts
+++ b/src/api/books/useGetBooksInfoPopular.ts
@@ -1,14 +1,9 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
 import { compareExpect } from "../../util/typeCheck";
 import { Book } from "../../type";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-export const useGetBooksInfoPopular = ({ setOpenTitleAndMessage }: Props) => {
+export const useGetBooksInfoPopular = () => {
   const [docs, setDocs] = useState<Book[]>([]);
 
   const { request } = useApi("get", "books/info", {
@@ -35,13 +30,7 @@ export const useGetBooksInfoPopular = ({ setOpenTitleAndMessage }: Props) => {
     setDocs(books);
   };
 
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(title, message || error.message);
-  };
-
-  useEffect(() => request(refineResponse, onError), []);
+  useEffect(() => request(refineResponse), []);
 
   return { docs };
 };

--- a/src/api/books/useGetBooksInfoSearch.ts
+++ b/src/api/books/useGetBooksInfoSearch.ts
@@ -7,7 +7,7 @@ export const useGetBooksInfoSearch = ({ limit }: { limit: number }) => {
   const { searchParams, searchResult, setSearchResult, setPage, setQuery } =
     useSearch();
 
-  const { request, Dialog } = useApi("get", "books/info/search", {
+  const { request } = useApi("get", "books/info/search", {
     query: searchParams.query,
     page: searchParams.page - 1,
     limit,
@@ -32,6 +32,5 @@ export const useGetBooksInfoSearch = ({ limit }: { limit: number }) => {
     page: searchParams.page,
     setPage,
     setQuery,
-    Dialog,
   };
 };

--- a/src/api/books/useGetBooksInfoSearchUrl.ts
+++ b/src/api/books/useGetBooksInfoSearchUrl.ts
@@ -20,7 +20,7 @@ export const useGetBooksInfoSearchUrl = () => {
   const [query, page, sort, category] =
     useParseUrlQueryString(searchUrlQueryKeys);
 
-  const { request, Dialog } = useApi("get", "books/info/search", {
+  const { request } = useApi("get", "books/info/search", {
     query,
     page: page ? page - 1 : 0,
     limit: 20,
@@ -73,6 +73,5 @@ export const useGetBooksInfoSearchUrl = () => {
 
   return {
     ...searchResult,
-    Dialog,
   };
 };

--- a/src/api/books/useGetBooksSearch.ts
+++ b/src/api/books/useGetBooksSearch.ts
@@ -8,7 +8,7 @@ export const useGetBooksSearch = ({ limit }: { limit: number }) => {
   const { searchParams, searchResult, setSearchResult, setPage, setQuery } =
     useSearch();
 
-  const { request, Dialog } = useApi("get", "books/search", {
+  const { request } = useApi("get", "books/search", {
     query: searchParams.query,
     page: searchParams.page - 1,
     limit,
@@ -53,6 +53,5 @@ export const useGetBooksSearch = ({ limit }: { limit: number }) => {
     page: searchParams.page,
     setPage,
     setQuery,
-    Dialog,
   };
 };

--- a/src/api/books/usePatchBooksUpdate.ts
+++ b/src/api/books/usePatchBooksUpdate.ts
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
 import { Book } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookTitle: string;
@@ -11,24 +11,25 @@ type Props = {
 export const usePatchBooksUpdate = ({ bookTitle, closeModal }: Props) => {
   const [change, setChange] = useState<Partial<Book>>();
 
-  const { request, setError, Dialog } = useApi("patch", "books/update", change);
+  const { request } = useApi("patch", "books/update", change);
+
+  const { addDialogWithTitleAndMessage } = useNewDialog();
 
   const onSuccess = () => {
-    setError("수정되었습니다", bookTitle, () => {
-      closeModal();
-      window.location.reload();
-    });
-  };
-
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setError(title, errorCode ? message : `${message}\r\n${error?.message}`);
+    addDialogWithTitleAndMessage(
+      `${bookTitle}수정`,
+      "수정되었습니다",
+      bookTitle,
+      () => {
+        closeModal();
+        window.location.reload();
+      },
+    );
   };
 
   useEffect(() => {
-    if (change) request(onSuccess, onError);
+    if (change) request(onSuccess);
   }, [change]);
 
-  return { setChange, Dialog };
+  return { setChange };
 };

--- a/src/api/histories/useGetHistories.ts
+++ b/src/api/histories/useGetHistories.ts
@@ -1,22 +1,20 @@
 import { useEffect, useState } from "react";
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { useSearch } from "../../hook/useSearch";
 import { compareExpect } from "../../util/typeCheck";
 import { History } from "../../type";
 
 type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
   initWho?: string;
 };
 
-export const useGetHistories = ({ setOpenTitleAndMessage, initWho }: Props) => {
+export const useGetHistories = ({ initWho }: Props) => {
   const { searchParams, searchResult, setSearchResult, setPage, setQuery } =
     useSearch();
   const [who, setWho] = useState(initWho ?? "all");
   const [type, setType] = useState("");
 
-  const { request, Dialog } = useApi("get", "histories", {
+  const { request } = useApi("get", "histories", {
     query: searchParams.query,
     page: searchParams.page - 1,
     limit: 5,
@@ -50,12 +48,8 @@ export const useGetHistories = ({ setOpenTitleAndMessage, initWho }: Props) => {
     });
   };
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
-  };
-
   useEffect(() => {
-    request(refineResponse, displayError);
+    request(refineResponse);
   }, [searchParams, who, type]);
 
   return {
@@ -67,6 +61,5 @@ export const useGetHistories = ({ setOpenTitleAndMessage, initWho }: Props) => {
     setQuery,
     setWho,
     setType,
-    Dialog,
   };
 };

--- a/src/api/lendings/useGetLendingsId.ts
+++ b/src/api/lendings/useGetLendingsId.ts
@@ -1,20 +1,15 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
 import { compareExpect } from "../../util/typeCheck";
 import { Lending } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   lendingId: number;
   closeModal: () => void;
-  setError: (title: string, message: string) => void;
 };
 
-export const useGetLendingsId = ({
-  lendingId,
-  closeModal,
-  setError,
-}: Props) => {
+export const useGetLendingsId = ({ lendingId, closeModal }: Props) => {
   const [lendingData, setLendingData] = useState<Lending>();
 
   const { request } = useApi("get", `lendings/${lendingId}`, {});
@@ -40,11 +35,9 @@ export const useGetLendingsId = ({
     setLendingData(lending);
   };
 
+  const { addErrorDialog } = useNewDialog();
   const displayError = (error: any) => {
-    closeModal();
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setError(title, errorCode ? message : error.message);
+    addErrorDialog(error, closeModal);
   };
 
   useEffect(() => {

--- a/src/api/lendings/useGetLendingsSearch.ts
+++ b/src/api/lendings/useGetLendingsSearch.ts
@@ -1,15 +1,10 @@
 import { useEffect, useState } from "react";
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { useSearch } from "../../hook/useSearch";
 import { compareExpect } from "../../util/typeCheck";
 import { Lending } from "../../type";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-export const useGetLendingsSearch = ({ setOpenTitleAndMessage }: Props) => {
+export const useGetLendingsSearch = () => {
   const { searchParams, searchResult, setSearchResult, setPage, setQuery } =
     useSearch();
   const [isSortNew, setIsSearchSort] = useState(false);
@@ -19,7 +14,7 @@ export const useGetLendingsSearch = ({ setOpenTitleAndMessage }: Props) => {
     setPage(1);
   };
 
-  const { request, Dialog } = useApi("get", "lendings/search", {
+  const { request } = useApi("get", "lendings/search", {
     query: searchParams.query,
     page: searchParams.page - 1,
     limit: 5,
@@ -50,12 +45,8 @@ export const useGetLendingsSearch = ({ setOpenTitleAndMessage }: Props) => {
     });
   };
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
-  };
-
   useEffect(() => {
-    request(refineResponse, displayError);
+    request(refineResponse);
   }, [searchParams, isSortNew]);
 
   return {
@@ -66,6 +57,5 @@ export const useGetLendingsSearch = ({ setOpenTitleAndMessage }: Props) => {
     setQuery,
     isSortNew,
     setIsSortNew,
-    Dialog,
   };
 };

--- a/src/api/lendings/useGetLendingsSearchId.ts
+++ b/src/api/lendings/useGetLendingsSearchId.ts
@@ -1,34 +1,34 @@
 import { useEffect } from "react";
 import { useApi } from "../../hook/useApi";
 import { useSearch } from "../../hook/useSearch";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   setLendingId: (id: number) => void;
   openModal: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
-export const useGetLendingsSearchId = ({
-  setLendingId,
-  openModal,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const useGetLendingsSearchId = ({ setLendingId, openModal }: Props) => {
   const { searchParams, setQuery } = useSearch();
   const { request } = useApi("get", "lendings/search", {
     query: searchParams.query,
     type: "bookId",
   });
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const refineResponse = (response: any) => {
     const result = response.data?.items;
     if (result && result?.length > 0 && result[0]?.id !== undefined) {
       setLendingId(result[0].id);
       openModal();
-    } else
-      setOpenTitleAndMessage(
-        "책을 다시 한번 확인해주세요.",
+    } else {
+      const title = "책을 다시 한번 확인해주세요.";
+      addDialogWithTitleAndMessage(
+        title,
+        title,
         "해당책의 대출기록이 없습니다.",
       );
+    }
   };
 
   useEffect(() => {

--- a/src/api/lendings/usePatchLendingsReturn.ts
+++ b/src/api/lendings/usePatchLendingsReturn.ts
@@ -1,18 +1,17 @@
 import { useState } from "react";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   lendingId: number;
   title: string;
   closeModal: () => void;
-  setError: (title: string, message: string, afterClose?: () => void) => void;
 };
 
 export const usePatchLendingsReturn = ({
   lendingId,
-  title,
+  title: bookTitle,
   closeModal,
-  setError,
 }: Props) => {
   const [condition, setCondition] = useState("");
 
@@ -21,16 +20,15 @@ export const usePatchLendingsReturn = ({
     condition,
   });
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
+
   const onSuccess = (response: any) => {
     closeModal();
-    setError(
-      `${
-        response.data?.reservedBook
-          ? "예약된 책입니다. 예약자를 위해 따로 보관해주세요."
-          : "반납되었습니다."
-      }`,
-      title,
-      () => window.location.reload(),
+    const title = response.data?.reservedBook
+      ? "예약된 책입니다. 예약자를 위해 따로 보관해주세요."
+      : "반납되었습니다.";
+    addDialogWithTitleAndMessage(title, title, bookTitle, () =>
+      window.location.reload(),
     );
   };
 

--- a/src/api/lendings/usePostLendings.ts
+++ b/src/api/lendings/usePostLendings.ts
@@ -1,20 +1,18 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
-import { setErrorDialog } from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   title: string;
   userId: number;
   bookId: number;
   closeModal: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
 export const usePostLendings = ({
   title,
   userId,
   bookId,
-  setOpenTitleAndMessage,
   closeModal,
 }: Props) => {
   const [condition, setCondition] = useState("");
@@ -24,12 +22,15 @@ export const usePostLendings = ({
     condition,
   });
 
+  const { addDialogWithTitleAndMessage, addErrorDialog } = useNewDialog();
+
   const onSuccess = () => {
-    setOpenTitleAndMessage("대출결과", `${title} - 대출완료`, closeModal);
+    const message = `${title} - 대출완료`;
+    addDialogWithTitleAndMessage(message, "대출결과", message, closeModal);
   };
 
   const onError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage, closeModal);
+    addErrorDialog(error, closeModal);
   };
 
   useEffect(() => {

--- a/src/api/lendings/usePostLendingsMultiple.ts
+++ b/src/api/lendings/usePostLendingsMultiple.ts
@@ -2,13 +2,13 @@ import { useState, useEffect, useMemo } from "react";
 import getErrorMessage from "../../constant/error";
 import { useApiMultiple } from "../../hook/useApiMultiple";
 import { Book, User } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   selectedBooks: Book[];
   setSelectedBooks: React.Dispatch<React.SetStateAction<Book[]>>;
   selectedUser: User;
   setSelectedUser: (user: User) => void;
-  setError: (title: string, message: string) => void;
   closeModal: () => void;
 };
 
@@ -17,7 +17,6 @@ export const usePostLendingsMultiple = ({
   setSelectedBooks,
   selectedUser,
   setSelectedUser,
-  setError,
   closeModal,
 }: Props) => {
   const [conditions, setConditions] = useState<string[]>([]);
@@ -38,6 +37,8 @@ export const usePostLendingsMultiple = ({
   let resultMessage = "";
   const lendingSuccess = selectedUser.lendings;
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
+
   const handleResult = (results: PromiseSettledResult<any>[]) => {
     results.forEach((result, index) => {
       const title = selectedBooks[index]?.title;
@@ -57,7 +58,7 @@ export const usePostLendingsMultiple = ({
     });
     setSelectedBooks([]);
     setSelectedUser({ ...selectedUser, lendings: lendingSuccess });
-    setError("대출결과", resultMessage);
+    addDialogWithTitleAndMessage(resultMessage, "대출결과", resultMessage);
     closeModal();
   };
 

--- a/src/api/like/useDeleteLike.ts
+++ b/src/api/like/useDeleteLike.ts
@@ -1,17 +1,8 @@
 import { useEffect, useState } from "react";
 import { compareExpect } from "../../util/typeCheck";
-import getErrorMessage from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 
-type Props = {
-  initBookInfoId?: number;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-export const useDeleteLike = ({
-  initBookInfoId,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const useDeleteLike = (initBookInfoId?: number) => {
   const [bookInfoId, setBookInfoId] = useState(initBookInfoId);
   const { request } = useApi("delete", `books/info/${bookInfoId}/like`);
   const [likeData, setLikeData] = useState({});
@@ -31,14 +22,8 @@ export const useDeleteLike = ({
     setLikeData(refinelikeData);
   };
 
-  const displayError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(title, errorCode ? message : error.message);
-  };
-
   useEffect(() => {
-    if (bookInfoId) request(refineResponse, displayError);
+    if (bookInfoId) request(refineResponse);
     setBookInfoId(undefined);
   }, [bookInfoId]);
 

--- a/src/api/like/useGetLike.ts
+++ b/src/api/like/useGetLike.ts
@@ -7,14 +7,12 @@ type Props = {
   initBookInfoId: number;
   setCurrentLike: (isLiked: boolean) => void;
   setCurrentLikeNum?: (likeNum: number) => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
 export const useGetLike = ({
   initBookInfoId,
   setCurrentLike,
   setCurrentLikeNum,
-  setOpenTitleAndMessage,
 }: Props) => {
   const { request } = useApi("get", `books/info/${initBookInfoId}/like`);
   const [likeData, setLikeData] = useState({});
@@ -36,14 +34,8 @@ export const useGetLike = ({
     setCurrentLikeNum && setCurrentLikeNum(refinelikeData[0].likeNum);
   };
 
-  const displayError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(title, errorCode ? message : error.message);
-  };
-
   useEffect(() => {
-    if (initBookInfoId) request(refineResponse, displayError);
+    if (initBookInfoId) request(refineResponse);
   }, []);
 
   return { likeData };

--- a/src/api/like/usePostLike.ts
+++ b/src/api/like/usePostLike.ts
@@ -1,17 +1,8 @@
 import { useEffect, useState } from "react";
-import getErrorMessage from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { compareExpect } from "../../util/typeCheck";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-  initBookInfoId?: number;
-};
-
-export const usePostLike = ({
-  setOpenTitleAndMessage,
-  initBookInfoId,
-}: Props) => {
+export const usePostLike = (initBookInfoId?: number) => {
   const [bookInfoId, setBookInfoId] = useState(initBookInfoId);
   const { request } = useApi("post", `books/info/${bookInfoId}/like`);
   const [likeData, setLikeData] = useState({});
@@ -29,15 +20,8 @@ export const usePostLike = ({
     );
     setLikeData(refinelikeData);
   };
-
-  const displayError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(title, errorCode ? message : error.message);
-  };
-
   useEffect(() => {
-    if (bookInfoId) request(refineResponse, displayError);
+    if (bookInfoId) request(refineResponse);
     setBookInfoId(undefined);
   }, [bookInfoId]);
 

--- a/src/api/reservations/useGetReservationsCount.ts
+++ b/src/api/reservations/useGetReservationsCount.ts
@@ -1,53 +1,37 @@
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookInfoId: number;
-
-  dialogDefaultConfig: any;
-  setDialogConfig: (config: any) => void;
-  openDialog: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
   postReservation: () => void;
 };
 
 export const useGetReservationsCount = ({
   bookInfoId,
-  dialogDefaultConfig,
-  setDialogConfig,
-  openDialog,
-  setOpenTitleAndMessage,
   postReservation,
 }: Props) => {
   const { request } = useApi("get", "reservations/count", {
     bookInfo: bookInfoId,
   });
+  const { addDialogWithConfig } = useNewDialog();
 
   const onSuccess = (response: any) => {
     const expectedRank = response?.data?.count;
     const title = `현재 예약대기자는 ${expectedRank}명입니다.
 예약하시겠습니까?`;
     const message = `주의: 예약도서는 2권 이상 대출할 수 없거나, 연체회원일 경우 대출이 제한됩니다.`;
-
-    setDialogConfig({
-      ...dialogDefaultConfig,
+    addDialogWithConfig(title, {
       firstButton: {
-        ...dialogDefaultConfig.firstButton,
         onClick: postReservation,
       },
       title,
       titleEmphasis: `${expectedRank}명`,
       message,
     });
-    openDialog();
-  };
-
-  const onError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
   };
 
   const getCountReservation = () => {
-    request(onSuccess, onError);
+    request(onSuccess);
   };
   return { getCountReservation };
 };

--- a/src/api/reservations/useGetReservationsSearch.ts
+++ b/src/api/reservations/useGetReservationsSearch.ts
@@ -29,7 +29,7 @@ export const useGetReservationsSearch = () => {
     return "all";
   };
 
-  const { request, Dialog } = useApi("get", "reservations/search", {
+  const { request } = useApi("get", "reservations/search", {
     query: searchParams.query,
     page: searchParams.page - 1,
     limit: 5,
@@ -66,6 +66,7 @@ export const useGetReservationsSearch = () => {
   useEffect(() => {
     request(refineResponse);
   }, [searchParams, filter]);
+
   return {
     reservedLoanList: searchResult.list as Reservation[],
     lastPage: searchResult.lastPage,
@@ -74,6 +75,5 @@ export const useGetReservationsSearch = () => {
     setQuery,
     filter,
     setFilter,
-    Dialog,
   };
 };

--- a/src/api/reservations/usePatchReservationsCancel.ts
+++ b/src/api/reservations/usePatchReservationsCancel.ts
@@ -1,47 +1,30 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
-type Props = {
-  defaultConfig: any;
-  setConfig: (config: any) => void;
-  setOpen: () => void;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
-};
-
-export const usePatchReservationsCancel = ({
-  defaultConfig,
-  setConfig,
-  setOpen,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePatchReservationsCancel = () => {
   const [reservationId, setReservationId] = useState<number>();
 
   const { request } = useApi("patch", `reservations/cancel/${reservationId}`);
-
+  const { addConfirmDialog, addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    setOpenTitleAndMessage("예약 취소가 완료되었습니다.", "", () =>
-      window.location.reload(),
+    addDialogWithTitleAndMessage(
+      "예약취소",
+      "예약 취소가 완료되었습니다.",
+      "",
+      () => window.location.reload(),
     );
   };
 
   const confirmCancelReservation = () => {
-    setConfig({
-      ...defaultConfig,
-      afterClose: () => setReservationId(undefined),
-      title: "예약을 취소하시겠습니까?",
-      message: "주의 : 예약취소는 대기순위를 잃고 되돌릴 수 없습니다.",
-      firstButton: {
-        ...defaultConfig.firstButton,
-        onClick: () => {
-          request(onSuccess);
-        },
+    addConfirmDialog(
+      `${reservationId} 예약취소`,
+      "예약을 취소하시겠습니까?",
+      "주의 : 예약취소는 대기순위를 잃고 되돌릴 수 없습니다.",
+      () => {
+        request(onSuccess);
       },
-    });
-    setOpen();
+    );
   };
 
   useEffect(() => {

--- a/src/api/reservations/usePostReservations.ts
+++ b/src/api/reservations/usePostReservations.ts
@@ -1,25 +1,16 @@
 import { useApi } from "../../hook/useApi";
-import { setErrorDialog } from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookInfoId: number;
-  dialogDefaultConfig: any;
-  setDialogConfig: (config: any) => void;
-  openDialog: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
-export const usePostReservations = ({
-  bookInfoId,
-  dialogDefaultConfig,
-  setDialogConfig,
-  openDialog,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePostReservations = ({ bookInfoId }: Props) => {
   const { request } = useApi("post", "reservations", {
     bookInfoId,
   });
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = (response: any) => {
     const rank = response?.data?.count;
     const lendabledate = response?.data?.lenderableDate?.slice(0, 10);
@@ -28,21 +19,11 @@ export const usePostReservations = ({
       rank === 1 && lendabledate
         ? `대출 가능 예상일자는 ${lendabledate}.입니다.`
         : "대출이 가능해지면 Slack 알림을 보내드리겠습니다.";
-    setDialogConfig({
-      ...dialogDefaultConfig,
-      title,
-      titleEmphasis: `${rank}순위`,
-      message,
-    });
-    openDialog();
-  };
-
-  const onError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
+    addDialogWithTitleAndMessage(title, title, message);
   };
 
   const postReservation = () => {
-    request(onSuccess, onError);
+    request(onSuccess);
   };
   return { postReservation };
 };

--- a/src/api/reviews/useGetMyReviewInfo.ts
+++ b/src/api/reviews/useGetMyReviewInfo.ts
@@ -6,7 +6,7 @@ export const useGetMyReviewInfo = () => {
   const [page, setPage] = useState(1);
   const [lastPage, setLastPage] = useState(10);
   const [reviewList, setReviewList] = useState<Review[]>([]);
-  const { request, Dialog } = useApi("get", `reviews/my-reviews`, {
+  const { request } = useApi("get", `reviews/my-reviews`, {
     limit: 5,
     page: page - 1,
     isMyReview: true,
@@ -29,6 +29,5 @@ export const useGetMyReviewInfo = () => {
     lastPage,
     reviewList,
     setReviewList,
-    Dialog,
   };
 };

--- a/src/api/reviews/useGetReviewInfo.js
+++ b/src/api/reviews/useGetReviewInfo.js
@@ -6,7 +6,7 @@ export const useGetReviewInfo = () => {
   const [lastPage, setLastPage] = useState(null);
   const [reviewList, setReviewList] = useState([]);
   const userId = JSON.parse(window.localStorage.getItem("user")).id;
-  const { request, Dialog } = useApi("get", `reviews`, {
+  const { request } = useApi("get", `reviews`, {
     userId,
     page: page - 1,
   });
@@ -28,6 +28,5 @@ export const useGetReviewInfo = () => {
     lastPage,
     reviewList,
     setReviewList,
-    Dialog,
   };
 };

--- a/src/api/reviews/useGetReviews.ts
+++ b/src/api/reviews/useGetReviews.ts
@@ -24,7 +24,7 @@ export const useGetReviews = () => {
     if (type) setParams({ ...params, disabled: type });
   };
 
-  const { request, Dialog } = useApi("get", "reviews", {
+  const { request } = useApi("get", "reviews", {
     ...params,
     page: params.page - 1,
   });
@@ -48,6 +48,5 @@ export const useGetReviews = () => {
     setSelectedType,
     reviewList: result.reviewList as Review[],
     lastPage: result.lastPage,
-    Dialog,
   };
 };

--- a/src/api/reviews/usePatchReviewsId.ts
+++ b/src/api/reviews/usePatchReviewsId.ts
@@ -1,37 +1,21 @@
 import { useEffect, useState } from "react";
-import getErrorMessage from "../../constant/error";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
-type Props = {
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
-};
-
-export const usePatchReviewsId = ({ setOpenTitleAndMessage }: Props) => {
+export const usePatchReviewsId = () => {
   const [reviewId, setReviewId] = useState<number>();
   const { request } = useApi("patch", `reviews/${reviewId}`);
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    setOpenTitleAndMessage("처리되었습니다", "", () =>
+    addDialogWithTitleAndMessage("patched", "처리되었습니다", "", () =>
       window.location.reload(),
-    );
-  };
-
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(
-      title,
-      errorCode ? message : `${message}\r\n${error?.message}`,
     );
   };
 
   useEffect(() => {
     if (reviewId !== undefined) {
-      request(onSuccess, onError);
+      request(onSuccess);
     }
   }, [reviewId]);
   return { setReviewId };

--- a/src/api/reviews/usePostReview.ts
+++ b/src/api/reviews/usePostReview.ts
@@ -1,17 +1,13 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookInfoId: number;
   changeTab: (tab: number) => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
-export const usePostReview = ({
-  bookInfoId,
-  changeTab,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePostReview = ({ bookInfoId, changeTab }: Props) => {
   const checkLogin = JSON.parse(window.localStorage.getItem("user") || "");
   const [content, setContent] = useState("");
   const { request } = useApi("post", "/reviews", {
@@ -22,13 +18,14 @@ export const usePostReview = ({
   const refineResponse = () => {
     changeTab(0);
   };
+  const { addDialogWithTitleAndMessage } = useNewDialog();
 
-  const displayError = async () => {
-    if (checkLogin === null) {
-      setOpenTitleAndMessage("로그인 후 입력해주세요.", "");
-    } else {
-      setOpenTitleAndMessage("10자 이상 420자 이하로 입력해주세요.", "");
-    }
+  const displayError = () => {
+    const title =
+      checkLogin === null
+        ? "로그인 후 입력해주세요."
+        : "10자 이상 420자 이하로 입력해주세요.";
+    addDialogWithTitleAndMessage(title, title, "");
   };
 
   useEffect(() => {

--- a/src/api/stock/useGetStockSearch.ts
+++ b/src/api/stock/useGetStockSearch.ts
@@ -1,15 +1,10 @@
 import { useEffect } from "react";
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
 import { useSearch } from "../../hook/useSearch";
 import { compareExpect } from "../../util/typeCheck";
 import { Book } from "../../type";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-export const useGetStockSearch = ({ setOpenTitleAndMessage }: Props) => {
+export const useGetStockSearch = () => {
   const { searchParams, setSearchResult, searchResult, setPage } = useSearch();
   const { request } = useApi("get", "stock/search", {
     page: searchParams.page - 1,
@@ -36,12 +31,8 @@ export const useGetStockSearch = ({ setOpenTitleAndMessage }: Props) => {
     });
   };
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
-  };
-
   useEffect(() => {
-    request(refineResponse, displayError);
+    request(refineResponse);
   }, [searchParams]);
 
   return {

--- a/src/api/stock/usePatchStockUpdate.ts
+++ b/src/api/stock/usePatchStockUpdate.ts
@@ -1,39 +1,23 @@
 import { useEffect, useState } from "react";
-import getErrorMessage from "../../constant/error";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
   addList: () => void;
 };
 
-export const usePatchStockUpdate = ({
-  setOpenTitleAndMessage,
-  addList,
-}: Props) => {
+export const usePatchStockUpdate = ({ addList }: Props) => {
   const [bookId, setBookId] = useState<number>();
   const { request } = useApi("patch", `stock/update`, { id: bookId });
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    setOpenTitleAndMessage("처리되었습니다", "", addList);
-  };
-
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(
-      title,
-      errorCode ? message : `${message}\r\n${error?.message}`,
-    );
+    addDialogWithTitleAndMessage("end", "처리되었습니다", "", addList);
   };
 
   useEffect(() => {
     if (bookId !== undefined) {
-      request(onSuccess, onError);
+      request(onSuccess);
     }
   }, [bookId]);
   return { setBookId };

--- a/src/api/tags/useDeleteTagsSuper.ts
+++ b/src/api/tags/useDeleteTagsSuper.ts
@@ -1,42 +1,31 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   removeTag: (tagId: number) => void;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-export const useDeleteTagsSuper = ({
-  removeTag,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const useDeleteTagsSuper = ({ removeTag }: Props) => {
   const [tagId, setTagId] = useState<number | undefined>(undefined);
 
   const { request } = useApi("delete", `/tags/super/${tagId}`);
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    setOpenTitleAndMessage("처리되었습니다", "", () => {
-      if (tagId) removeTag(tagId);
-    });
-  };
-
-  const onError = (error: any) => {
-    const errorCode = parseInt(error?.response?.data?.errorCode, 10);
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setOpenTitleAndMessage(
-      title,
-      errorCode ? message : `${message}\r\n${error?.message}`,
+    addDialogWithTitleAndMessage(
+      `${tagId}patched`,
+      "처리되었습니다",
+      "",
+      () => {
+        tagId && removeTag(tagId);
+      },
     );
   };
 
   useEffect(() => {
     if (tagId !== undefined) {
-      request(onSuccess, onError);
+      request(onSuccess);
     }
   }, [tagId]);
 

--- a/src/api/tags/useGetTags.ts
+++ b/src/api/tags/useGetTags.ts
@@ -11,7 +11,7 @@ export const useGetTags = () => {
     setFilter(filter === newFilter ? null : newFilter);
   };
 
-  const { request, Dialog } = useApi("get", "tags", {
+  const { request } = useApi("get", "tags", {
     ...searchParams,
     title: searchParams.query,
     page: searchParams.page - 1,
@@ -36,6 +36,5 @@ export const useGetTags = () => {
     setQuery,
     filter,
     setFilter: changeFilter,
-    Dialog,
   };
 };

--- a/src/api/tags/useGetTagsBookInfoId.ts
+++ b/src/api/tags/useGetTagsBookInfoId.ts
@@ -4,7 +4,7 @@ import { useApi } from "../../hook/useApi";
 
 export const useGetTagsBookInfoId = (id?: number) => {
   const [tagList, setTagList] = useState<Tag[]>([]);
-  const { request, Dialog } = useApi("get", `/tags/${id}`);
+  const { request } = useApi("get", `/tags/${id}`);
 
   const refineResponse = (response: any) => {
     setTagList(response.data);
@@ -24,5 +24,5 @@ export const useGetTagsBookInfoId = (id?: number) => {
     setTagList(prev => prev.filter(tag => tag.id !== tagId));
   };
 
-  return { tagList, addTag, removeTag, Dialog };
+  return { tagList, addTag, removeTag };
 };

--- a/src/api/tags/useGetTagsSuperTagIdSub.ts
+++ b/src/api/tags/useGetTagsSuperTagIdSub.ts
@@ -1,21 +1,12 @@
 import { useEffect, useState } from "react";
 import { Tag } from "../../type";
 import { useApi } from "../../hook/useApi";
-import { setErrorDialog } from "../../constant/error";
 
 type Props = {
   tagId: number;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-export const useGetTagsSuperTagIdSub = ({
-  tagId,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const useGetTagsSuperTagIdSub = ({ tagId }: Props) => {
   const [subTagList, setSubTagList] = useState<Tag[]>([]);
   const [isOpened, setOpened] = useState(false);
   const toggleOpened = () => setOpened(!isOpened);
@@ -26,12 +17,8 @@ export const useGetTagsSuperTagIdSub = ({
     setSubTagList(response.data);
   };
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
-  };
-
   useEffect(() => {
-    if (isOpened) request(saveTagList, displayError);
+    if (isOpened) request(saveTagList);
   }, [isOpened]);
 
   const addSubTag = (subTag: Tag) => {

--- a/src/api/tags/usePatchTagsBookInfoIdMerge.ts
+++ b/src/api/tags/usePatchTagsBookInfoIdMerge.ts
@@ -1,21 +1,12 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
-import { setErrorDialog } from "../../constant/error";
 import { Tag } from "../../type";
 
 type Props = {
   bookInfoId: number;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-export const usePatchTagsBookInfoIdMerge = ({
-  bookInfoId,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePatchTagsBookInfoIdMerge = ({ bookInfoId }: Props) => {
   const [params, setParams] = useState<{
     subTag: Tag;
     superTag: Tag | null;
@@ -26,12 +17,8 @@ export const usePatchTagsBookInfoIdMerge = ({
     superTagId: params?.superTag?.id || null,
   });
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
-  };
-
   useEffect(() => {
-    if (params) request(() => {}, displayError);
+    if (params) request(() => {});
   }, [params]);
 
   return { setParams };

--- a/src/api/tags/usePatchTagsSub.ts
+++ b/src/api/tags/usePatchTagsSub.ts
@@ -1,36 +1,26 @@
 import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
-import { setErrorDialog } from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type PatchTagsSubParamType = {
   id: number;
   visibility: "public" | "private";
 };
 
-export const usePatchTagsSub = ({
-  setOpenTitleAndMessage,
-}: {
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
-}) => {
+export const usePatchTagsSub = () => {
   const [params, setParams] = useState<PatchTagsSubParamType | null>(null);
   const { request } = useApi("patch", "tags/sub", params);
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const displaySuccess = () => {
-    setOpenTitleAndMessage("처리되었습니다", "", () =>
+    addDialogWithTitleAndMessage("patched", "처리되었습니다", "", () =>
       window.location.reload(),
     );
-  };
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
   };
 
   useEffect(() => {
     if (params) {
-      request(displaySuccess, displayError);
+      request(displaySuccess);
     }
   }, [params]);
   return { setParams };

--- a/src/api/tags/usePostTagsSuper.ts
+++ b/src/api/tags/usePostTagsSuper.ts
@@ -1,23 +1,14 @@
 import { useState } from "react";
 import { useApi } from "../../hook/useApi";
 import { Tag } from "../../type";
-import { setErrorDialog } from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookInfoId: number;
   addTag: (tag: Tag) => void;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-export const usePostTagsSuper = ({
-  bookInfoId,
-  addTag,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePostTagsSuper = ({ bookInfoId, addTag }: Props) => {
   const [newTagName, setNewTagName] = useState("");
 
   const { request } = useApi("post", "/tags/super", {
@@ -25,18 +16,20 @@ export const usePostTagsSuper = ({
     content: newTagName.replace(/ /g, "_"),
   });
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = (res: any) => {
     const newTag = res.data;
     addTag(newTag);
-    setOpenTitleAndMessage("태그가 추가되었습니다.", newTag.content);
-  };
 
-  const displayError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage);
+    addDialogWithTitleAndMessage(
+      `${newTag.content} 추가`,
+      "태그가 추가되었습니다.",
+      newTag.content,
+    );
   };
 
   return {
-    postSuperTag: () => request(onSuccess, displayError),
+    postSuperTag: () => request(onSuccess),
     newTagName,
     setNewTagName,
   };

--- a/src/api/users/useGetUsersSearch.ts
+++ b/src/api/users/useGetUsersSearch.ts
@@ -14,7 +14,7 @@ export const useGetUsersSearch = ({ limit }: { limit: number }) => {
     setQueryNoDelay,
   } = useSearch();
 
-  const { request, Dialog } = useApi("get", "users/search", {
+  const { request } = useApi("get", "users/search", {
     nicknameOrEmail: searchParams.query,
     page: searchParams.page - 1,
     limit,
@@ -72,6 +72,5 @@ export const useGetUsersSearch = ({ limit }: { limit: number }) => {
     setPage,
     setQuery,
     setQueryNoDelay,
-    Dialog,
   };
 };

--- a/src/api/users/useGetUsersSearchId.ts
+++ b/src/api/users/useGetUsersSearchId.ts
@@ -2,17 +2,12 @@ import { useEffect, useState } from "react";
 import { useApi } from "../../hook/useApi";
 import { compareExpect } from "../../util/typeCheck";
 import { User } from "../../type";
-import { setErrorDialog } from "../../constant/error";
 
 type Props = {
   userId: number;
-  setDialogTitleAndMessage: (title: string, message: string) => void;
 };
 
-export const useGetUsersSearchId = ({
-  userId,
-  setDialogTitleAndMessage,
-}: Props) => {
+export const useGetUsersSearchId = ({ userId }: Props) => {
   const [userInfo, setUserInfo] = useState<User>();
 
   const { request } = useApi("get", "users/search", {
@@ -57,11 +52,7 @@ export const useGetUsersSearchId = ({
     setUserInfo(user[0]);
   };
 
-  const onError = (error: any) => {
-    setErrorDialog(error, setDialogTitleAndMessage);
-  };
-
-  useEffect(() => request(refineResponse, onError), []);
+  useEffect(() => request(refineResponse), []);
 
   return { userInfo };
 };

--- a/src/api/users/usePatchUsersMyupdate.ts
+++ b/src/api/users/usePatchUsersMyupdate.ts
@@ -1,36 +1,27 @@
 import { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { setErrorDialog } from "../../constant/error";
 import { useApi } from "../../hook/useApi";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   modeString: string;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-export const usePatchUsersMyupdate = ({
-  modeString,
-  setOpenTitleAndMessage,
-}: Props) => {
+export const usePatchUsersMyupdate = ({ modeString }: Props) => {
   const [patchData, setPatchData] = useState<{
     email?: string;
     password?: string;
   }>();
   const { request } = useApi("patch", "/users/myupdate", patchData);
   const navigate = useNavigate();
-
+  const { addDialogWithTitleAndMessage, addErrorDialog } = useNewDialog();
   const onSuccess = () => {
-    setOpenTitleAndMessage(`${modeString} 변경 성공`, "", () =>
-      navigate("/auth"),
-    );
+    const title = `${modeString} 변경 성공`;
+    addDialogWithTitleAndMessage(title, title, "", () => navigate("/auth"));
   };
 
   const onError = (error: any) => {
-    setErrorDialog(error, setOpenTitleAndMessage, () => navigate("-1"));
+    addErrorDialog(error, () => navigate("-1"));
   };
 
   useEffect(() => {

--- a/src/api/users/usePatchUsersUpdate.ts
+++ b/src/api/users/usePatchUsersUpdate.ts
@@ -9,11 +9,7 @@ type Props = {
 
 export const usePatchUsersUpdate = ({ userId, exitEditMode }: Props) => {
   const [patchData, setPatchData] = useState<Partial<User>>();
-  const { request, Dialog } = useApi(
-    "patch",
-    `users/update/${userId}`,
-    patchData,
-  );
+  const { request } = useApi("patch", `users/update/${userId}`, patchData);
   const expectedItem: { [key: string]: string } = {
     nickname: "string",
     intraId: "number",
@@ -40,5 +36,5 @@ export const usePatchUsersUpdate = ({ userId, exitEditMode }: Props) => {
     if (patchData !== null) request(onSuccess);
   }, [patchData]);
 
-  return { requestUpdate, Dialog };
+  return { requestUpdate };
 };

--- a/src/api/users/usePostUsersCreate.ts
+++ b/src/api/users/usePostUsersCreate.ts
@@ -1,7 +1,7 @@
 import { useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useApi } from "../../hook/useApi";
-import getErrorMessage from "../../constant/error";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type RegisterDataItem = {
   value: string;
@@ -22,14 +22,16 @@ export const usePostUsersCreate = () => {
     confirmPassword: { value: "", error: "", ref: confirmPasswordRef },
   });
 
-  const { request, setError, Dialog } = useApi("post", "users/create", {
+  const { request } = useApi("post", "users/create", {
     email: registerData.email.value,
     password: registerData.password.value,
   });
   const navigate = useNavigate();
+  const { addDialogWithTitleAndMessage, addErrorDialog } = useNewDialog();
 
   const displaySuccess = () => {
-    setError(
+    addDialogWithTitleAndMessage(
+      "회원가입 완료",
       "회원가입 완료",
       "환영합니다. 로그인 후 집현전 서비스를 이용하세요.",
       () => navigate("/login"),
@@ -60,13 +62,12 @@ export const usePostUsersCreate = () => {
       registerData.password.ref.current?.focus();
       return;
     }
-    const errorMessage = errorCode ? getErrorMessage(errorCode) : error.message;
-    setError(errorMessage, "");
+    addErrorDialog(error);
   };
 
   const requestRegister = () => {
     request(displaySuccess, displayError);
   };
 
-  return { registerData, requestRegister, Dialog, setRegisterData };
+  return { registerData, requestRegister, setRegisterData };
 };

--- a/src/atom/dialogConfigs.ts
+++ b/src/atom/dialogConfigs.ts
@@ -1,0 +1,7 @@
+import { atom } from "recoil";
+import { DialogConfig } from "../type/DialogConfig";
+
+export const dialogConfigs = atom<DialogConfig[]>({
+  key: "dialogConfigs",
+  default: [],
+});

--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -3,7 +3,6 @@ import { useLocation, useParams } from "react-router-dom";
 import { useGetBooksInfoId } from "../../api/books/useGetBooksInfoId";
 import BookReservation from "./BookReservation";
 import BookStatus from "./BookStatus";
-import { useDialog } from "../../hook/useDialog";
 import Review from "./review/Review";
 import Banner from "../utils/Banner";
 import Image from "../utils/Image";
@@ -16,14 +15,7 @@ const BookDetail = () => {
   const myRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
   useEffect(() => myRef.current?.scrollIntoView(), []);
-  const {
-    Dialog,
-    defaultConfig: dialogDefaultConfig,
-    setConfig: setDialogConfig,
-    setOpen: openDialog,
-    setOpenTitleAndMessage,
-  } = useDialog();
-  const { bookDetailInfo } = useGetBooksInfoId({ id, setOpenTitleAndMessage });
+  const { bookDetailInfo } = useGetBooksInfoId({ id });
 
   if (!bookDetailInfo) return null;
   const isAvailableReservation = () => {
@@ -64,10 +56,6 @@ const BookDetail = () => {
               <BookReservation
                 bookInfoId={+id}
                 isAvailableReservation={isAvailableReservation() || false}
-                dialogDefaultConfig={dialogDefaultConfig}
-                setDialogConfig={setDialogConfig}
-                setOpenTitleAndMessage={setOpenTitleAndMessage}
-                openDialog={openDialog}
               />
             </div>
             <div className="book-detail__info">
@@ -119,7 +107,6 @@ const BookDetail = () => {
           <Review bookInfoId={id} />
         </div>
       </section>
-      <Dialog />
     </main>
   );
 };

--- a/src/component/book/BookReservation.tsx
+++ b/src/component/book/BookReservation.tsx
@@ -8,24 +8,9 @@ import "../../asset/css/Reservation.css";
 type Props = {
   bookInfoId: number;
   isAvailableReservation: boolean;
-  dialogDefaultConfig: any;
-  setDialogConfig: (config: any) => void;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
-  openDialog: () => void;
 };
 
-const BookReservation = ({
-  bookInfoId,
-  isAvailableReservation,
-  dialogDefaultConfig,
-  setDialogConfig,
-  setOpenTitleAndMessage,
-  openDialog,
-}: Props) => {
+const BookReservation = ({ bookInfoId, isAvailableReservation }: Props) => {
   if (!isAvailableReservation)
     return (
       <div className="reservation__rentable">
@@ -36,18 +21,10 @@ const BookReservation = ({
 
   const { postReservation } = usePostReservations({
     bookInfoId,
-    dialogDefaultConfig,
-    setDialogConfig,
-    openDialog,
-    setOpenTitleAndMessage,
   });
 
   const { getCountReservation } = useGetReservationsCount({
     bookInfoId,
-    dialogDefaultConfig,
-    setDialogConfig,
-    openDialog,
-    setOpenTitleAndMessage,
     postReservation,
   });
 

--- a/src/component/book/like/Like.tsx
+++ b/src/component/book/like/Like.tsx
@@ -2,7 +2,6 @@ import { useState } from "react";
 import { usePostLike } from "../../../api/like/usePostLike";
 import { useDeleteLike } from "../../../api/like/useDeleteLike";
 import { useGetLike } from "../../../api/like/useGetLike";
-import { useDialog } from "../../../hook/useDialog";
 import ShowLike from "./ShowLike";
 import "../../../asset/css/BookDetail.css";
 
@@ -14,19 +13,13 @@ const Like = ({ initBookInfoId }: Props) => {
   const [currentLike, setCurrentLike] = useState(false);
   const [currentLikeNum, setCurrentLikeNum] = useState(0);
 
-  const { setOpenTitleAndMessage } = useDialog();
   useGetLike({
-    setOpenTitleAndMessage,
     initBookInfoId: +initBookInfoId,
     setCurrentLike,
     setCurrentLikeNum,
   });
-  const { setBookInfoId: setDeleteLike } = useDeleteLike({
-    setOpenTitleAndMessage,
-  });
-  const { setBookInfoId: setPostLike } = usePostLike({
-    setOpenTitleAndMessage,
-  });
+  const { setBookInfoId: setDeleteLike } = useDeleteLike();
+  const { setBookInfoId: setPostLike } = usePostLike();
   const deleteLike = () => {
     setCurrentLike(false);
     setDeleteLike(+initBookInfoId);

--- a/src/component/book/review/HandleReview.tsx
+++ b/src/component/book/review/HandleReview.tsx
@@ -4,10 +4,10 @@ import { splitDate } from "../../../util/date";
 import Image from "../../utils/Image";
 import UserEdit from "../../../asset/img/edit.svg";
 import DeleteButton from "../../../asset/img/x_button.svg";
-import { useDialog } from "../../../hook/useDialog";
 import "../../../asset/css/Review.css";
 import { User } from "@sentry/react";
 import { Review } from "../../../type";
+import { useNewDialog } from "../../../hook/useNewDialog";
 
 type Props = {
   data: Review;
@@ -26,14 +26,6 @@ const HandleReview = ({
   type,
   onClickDel,
 }: Props) => {
-  const {
-    Dialog,
-    config,
-    setOpenTitleAndMessage,
-    setConfig: setDialogConfig,
-    setOpen: openDialog,
-    setClose: closeDialog,
-  } = useDialog();
   const [fixReview, setFixReview] = useState(false);
   const [content, setContent] = useState(data.content);
   const uploadDate = splitDate(createdAt)[0];
@@ -59,24 +51,14 @@ const HandleReview = ({
     onClickDel(data.reviewsId);
   };
 
+  const { addConfirmDialog, addDialogWithTitleAndMessage } = useNewDialog();
   const deleteBtn = () => {
-    setDialogConfig({
-      ...config,
-      title: "리뷰를 삭제하시겠습니까?",
-      buttonAlign: "basic",
-      numberOfButtons: 2,
-      firstButton: {
-        text: "확인하기",
-        color: "red",
-        onClick: deleteReview,
-      },
-      secondButton: {
-        text: "취소하기",
-        color: "grey",
-        onClick: closeDialog,
-      },
-    });
-    openDialog();
+    addConfirmDialog(
+      "삭제확인",
+      "리뷰를 삭제하시겠습니까?",
+      data.content,
+      deleteReview,
+    );
   };
 
   const patchReview = () => {
@@ -88,7 +70,11 @@ const HandleReview = ({
         setFixReview(!fixReview);
       })
       .catch(() => {
-        setOpenTitleAndMessage("10자 이상 420자 이하로 입력해주세요.", "");
+        addDialogWithTitleAndMessage(
+          "error",
+          "10자 이상 420자 이하로 입력해주세요.",
+          "",
+        );
       });
   };
 
@@ -175,7 +161,6 @@ const HandleReview = ({
           )}
         </div>
       ) : null}
-      <Dialog />
     </div>
   );
 };

--- a/src/component/book/review/PostReview.tsx
+++ b/src/component/book/review/PostReview.tsx
@@ -6,30 +6,13 @@ import {
 } from "react";
 import "../../../asset/css/Review.css";
 import Button from "../../utils/Button";
+import { useNewDialog } from "../../../hook/useNewDialog";
 
 type Props = {
   onClickPost: (post: string) => void;
-  setDialogConfig: (config: any) => void;
-  Dialog: ReactNode;
-  openDialog: () => void;
-  closeDialog: () => void;
-  config: any;
-  setOpenTitleAndMessage: (
-    title: string,
-    message: string,
-    afterClose?: () => void,
-  ) => void;
 };
 
-const PostReview = ({
-  onClickPost,
-  Dialog,
-  config,
-  openDialog,
-  closeDialog,
-  setDialogConfig,
-  setOpenTitleAndMessage,
-}: Props) => {
+const PostReview = ({ onClickPost }: Props) => {
   const [content, setContent] = useState("");
   const checkLogin = JSON.parse(window.localStorage.getItem("user") || "");
   const checkValidUser = () => {
@@ -46,40 +29,25 @@ const PostReview = ({
     setContent(e.target.value);
   };
 
+  const { addDialogWithTitleAndMessage, addConfirmDialog } = useNewDialog();
   const submitReview = () => {
     const validUser = checkValidUser();
     if (validUser === false) {
-      setOpenTitleAndMessage(
-        "42 인증 후 리뷰 등록이 가능합니다.",
-        "",
-        closeDialog,
-      );
+      const title = "42 인증 후 리뷰 등록이 가능합니다.";
+      addDialogWithTitleAndMessage(title, title, "");
       return;
     }
     onClickPost(content);
-    closeDialog();
   };
 
   const onSubmitHandler: FormEventHandler = e => {
     e.preventDefault();
-    console.log(content);
-    setDialogConfig({
-      ...config,
-      title: "리뷰를 등록하시겠습니까?",
-      buttonAlign: "basic",
-      numberOfButtons: 2,
-      firstButton: {
-        text: "확인하기",
-        color: "red",
-        onClick: submitReview,
-      },
-      secondButton: {
-        text: "취소하기",
-        color: "grey",
-        onClick: closeDialog,
-      },
-    });
-    openDialog();
+    addConfirmDialog(
+      `${content} 리뷰등록 확인`,
+      "리뷰를 등록하시겠습니까?",
+      "",
+      submitReview,
+    );
   };
 
   return (
@@ -101,7 +69,6 @@ const PostReview = ({
           <Button type="submit" value="게시하기" color="red" />
         </div>
       </form>
-      {Dialog}
     </div>
   );
 };

--- a/src/component/book/review/Review.tsx
+++ b/src/component/book/review/Review.tsx
@@ -3,7 +3,6 @@ import PostReview from "./PostReview";
 import ShowReviews from "./ShowReviews";
 import { useTabFocus } from "../../../hook/useTabFocus";
 import { usePostReview } from "../../../api/reviews/usePostReview";
-import { useDialog } from "../../../hook/useDialog";
 import "../../../asset/css/Tabs.css";
 import "../../../asset/css/Review.css";
 
@@ -13,16 +12,7 @@ type Props = {
 
 const Review = ({ bookInfoId }: Props) => {
   const { currentTab, changeTab } = useTabFocus(0, reviewTabList);
-  const {
-    Dialog,
-    config,
-    setConfig: setDialogConfig,
-    setOpen: openDialog,
-    setClose: closeDialog,
-    setOpenTitleAndMessage,
-  } = useDialog();
   const { setContent } = usePostReview({
-    setOpenTitleAndMessage,
     bookInfoId: +bookInfoId,
     changeTab,
   });
@@ -49,15 +39,7 @@ const Review = ({ bookInfoId }: Props) => {
         {currentTab === "showReviews" ? (
           <ShowReviews bookInfoId={+bookInfoId} type="bookReviews" />
         ) : (
-          <PostReview
-            onClickPost={setContent}
-            Dialog={<Dialog />}
-            config={config}
-            openDialog={openDialog}
-            closeDialog={closeDialog}
-            setDialogConfig={setDialogConfig}
-            setOpenTitleAndMessage={setOpenTitleAndMessage}
-          />
+          <PostReview onClickPost={setContent} />
         )}
       </div>
     </>

--- a/src/component/book/tag/CreateTagModal.tsx
+++ b/src/component/book/tag/CreateTagModal.tsx
@@ -25,7 +25,7 @@ const CreateTagModal = ({
 
   const location = useLocation();
   const bookId = location.pathname.split("/")[2];
-  const { request, Dialog } = useApi("post", `/tags/default`, {
+  const { request } = useApi("post", `/tags/default`, {
     bookInfoId: +bookId,
     createContent,
   });
@@ -52,7 +52,6 @@ const CreateTagModal = ({
 
   return (
     <div>
-      <Dialog />
       <ul>
         <button className="button_tag-box-sub">{createContent}</button>
       </ul>

--- a/src/component/book/tag/TagModal.tsx
+++ b/src/component/book/tag/TagModal.tsx
@@ -10,7 +10,7 @@ import { useApi } from "../../../hook/useApi";
 
 const TagModal = ({ id }: TagType) => {
   const [subTagData, setSubTagData] = useState([]);
-  const { request, Dialog } = useApi("get", `/tags/${id}/sub`);
+  const { request } = useApi("get", `/tags/${id}/sub`);
 
   useEffect(() => {
     const getSubTagRequest = (res: any) => {
@@ -21,7 +21,6 @@ const TagModal = ({ id }: TagType) => {
 
   return (
     <div className="button_tag-modal-background">
-      <Dialog />
       {subTagData.map((item: TagType) => (
         <Tag
           key={item.id}

--- a/src/component/book/tag/TagWrapper.tsx
+++ b/src/component/book/tag/TagWrapper.tsx
@@ -16,7 +16,7 @@ type TagData = {
 
 const TagWrapper = ({ bookInfoId }: TagProps) => {
   const [tagData, setTagData] = useState<TagData[]>([]);
-  const { request, Dialog } = useApi("get", `/tags/${bookInfoId}`);
+  const { request } = useApi("get", `/tags/${bookInfoId}`);
 
   useEffect(() => {
     const getTagRequest = (res: any) => {
@@ -27,7 +27,6 @@ const TagWrapper = ({ bookInfoId }: TagProps) => {
 
   return (
     <div className="none-drag">
-      <Dialog />
       <TagList tagData={tagData} setTagData={setTagData} />
     </div>
   );

--- a/src/component/bookManagement/BookManagement.tsx
+++ b/src/component/bookManagement/BookManagement.tsx
@@ -9,8 +9,9 @@ import Banner from "../utils/Banner";
 
 const BookManagement = () => {
   const [printList, setPrintList] = useState<Book[]>([]);
-  const { bookList, lastPage, page, setPage, setQuery, Dialog } =
-    useGetBooksSearch({ limit: 10 });
+  const { bookList, lastPage, page, setPage, setQuery } = useGetBooksSearch({
+    limit: 10,
+  });
 
   const addBookById = (bookId: number) => {
     const book = bookList.find(item => item.bookId === bookId);
@@ -32,7 +33,6 @@ const BookManagement = () => {
 
   return (
     <main>
-      <Dialog />
       <Banner img="admin" titleKo="도서 관리" titleEn="BOOK MANAGEMENT" />
       <Tabs tabList={bookManagementTabList} />
       <BookManagementBooksList

--- a/src/component/bookManagement/BookManagementModalDetail.tsx
+++ b/src/component/bookManagement/BookManagementModalDetail.tsx
@@ -30,7 +30,7 @@ const BookManagementModalDetail = ({ book, closeModal }: Props) => {
   const statusRef = useRef(null);
   const categoryRef = useRef(null);
 
-  const { setChange, Dialog } = usePatchBooksUpdate({
+  const { setChange } = usePatchBooksUpdate({
     bookTitle: book.title,
     closeModal,
   });
@@ -105,7 +105,6 @@ const BookManagementModalDetail = ({ book, closeModal }: Props) => {
 
   return (
     <div className="book-management__detail__wrarpper">
-      <Dialog />
       <p className="book-management__detail__title">도서정보</p>
       <div className="book-management__detail__book-info">
         <Image

--- a/src/component/bookStock/BookStockDetailModal.tsx
+++ b/src/component/bookStock/BookStockDetailModal.tsx
@@ -2,7 +2,6 @@ import { useGetBooksIdForStock } from "../../api/books/useGetBooksIdForStock";
 import BookDetailView from "../utils/BookDetailView";
 import SpanWithLabel from "../utils/SpanWithLabel";
 import Button from "../utils/Button";
-import { useDialog } from "../../hook/useDialog";
 import { bookStatus } from "../../constant/status";
 import { usePatchStockUpdate } from "../../api/stock/usePatchStockUpdate";
 import { Book } from "../../type";
@@ -15,15 +14,12 @@ type Props = {
 };
 
 const BookStockDetailModal = ({ bookId, closeModal, addChecked }: Props) => {
-  const { setOpenTitleAndMessage, Dialog } = useDialog();
   const { bookDetail: book } = useGetBooksIdForStock({
     id: bookId,
-    setOpenTitleAndMessage,
     closeModal,
   });
 
   const { setBookId } = usePatchStockUpdate({
-    setOpenTitleAndMessage,
     addList: () => {
       if (book) addChecked(book);
       closeModal();
@@ -63,7 +59,6 @@ const BookStockDetailModal = ({ bookId, closeModal, addChecked }: Props) => {
           }
         />
       ) : null}
-      <Dialog />
     </>
   );
 };

--- a/src/component/bookStock/BookStockNeedToCheckList.tsx
+++ b/src/component/bookStock/BookStockNeedToCheckList.tsx
@@ -4,14 +4,10 @@ import InquireBoxTitle from "../utils/InquireBoxTitle";
 import InquireBoxBody from "../utils/InquireBoxBody";
 import Pagination from "../utils/Pagination";
 import Book from "../../asset/img/admin_icon.svg";
-import { useDialog } from "../../hook/useDialog";
 import "../../asset/css/BookStockNeedToCheckList.css";
 
 const BookStockNeedToCheckList = () => {
-  const { setOpenTitleAndMessage, Dialog } = useDialog();
-  const { page, setPage, lastPage, list } = useGetStockSearch({
-    setOpenTitleAndMessage,
-  });
+  const { page, setPage, lastPage, list } = useGetStockSearch();
 
   return (
     <section>
@@ -31,7 +27,6 @@ const BookStockNeedToCheckList = () => {
           className="book-stock__need-to__pagination"
         />
       </InquireBoxBody>
-      <Dialog />
     </section>
   );
 };

--- a/src/component/bookStock/BookStockNeedToCheckListLine.tsx
+++ b/src/component/bookStock/BookStockNeedToCheckListLine.tsx
@@ -2,34 +2,33 @@ import { MouseEventHandler } from "react";
 import InquireBoxItem from "../utils/InquireBoxItem";
 import InquireBoxLine from "../utils/InquireBoxLine";
 import { usePatchBooksUpdate } from "../../api/books/usePatchBooksUpdate";
-import { useDialog } from "../../hook/useDialog";
 import { Book } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   book: Book;
 };
 
 const BookStockNeedToCheckListLine = ({ book }: Props) => {
-  const {
-    setClose: closeConfirm,
-    Dialog: ConfirmDialog,
-    setOpenConfirm,
-  } = useDialog();
-  const { setChange, Dialog: ResultDialog } = usePatchBooksUpdate({
+  const { setChange } = usePatchBooksUpdate({
     bookTitle: book.title,
-    closeModal: closeConfirm,
+    closeModal: () => {},
   });
 
+  const { addConfirmDialog } = useNewDialog();
   const setLostBook: MouseEventHandler<HTMLButtonElement> = e => {
     const unFound = e.currentTarget;
-    setOpenConfirm("분실처리하시겠습니까?", unFound.value, () => {
-      setChange({ bookId: +unFound.id, status: 1 });
-    });
+    addConfirmDialog(
+      `${unFound.id}분실`,
+      "분실처리하시겠습니까?",
+      unFound.value,
+      () => {
+        setChange({ bookId: +unFound.id, status: 1 });
+      },
+    );
   };
   return (
     <InquireBoxLine key={book.bookId}>
-      <ConfirmDialog />
-      <ResultDialog />
       <InquireBoxItem keyString="bookId" value={book.bookId} />
       <InquireBoxItem keyString="callSign" value={book.callSign} />
       <InquireBoxItem keyString="category" value={book.category} />

--- a/src/component/eLibraryIn42Box/ELibraryNew.jsx
+++ b/src/component/eLibraryIn42Box/ELibraryNew.jsx
@@ -2,7 +2,7 @@ import { useGetBooksInfoNew } from "../../api/books/useGetBooksInfoNew";
 import ELibraryBook from "./ELibraryBook";
 import ELibraryTitleWithMore from "./ELibraryTitleWithMore";
 const ELibraryNew = () => {
-  const { bookList } = useGetBooksInfoNew({ setOpenTitleAndMessage: () => {} });
+  const { bookList } = useGetBooksInfoNew();
   return (
     <>
       <ELibraryTitleWithMore title="신착자료" />

--- a/src/component/history/History.tsx
+++ b/src/component/history/History.tsx
@@ -7,7 +7,6 @@ import Banner from "../utils/Banner";
 import Pagination from "../utils/Pagination";
 import { useModal } from "../../hook/useModal";
 import InquireBoxTitle from "../utils/InquireBoxTitle";
-import { useDialog } from "../../hook/useDialog";
 import { useGetHistories } from "../../api/histories/useGetHistories";
 import { rentTabList } from "../../constant/tablist";
 import Book from "../../asset/img/book-arrow-up-free-icon-font.svg";
@@ -17,13 +16,11 @@ import "../../asset/css/Histories.css";
 const History = () => {
   const [historyInfo, setHistoryInfo] = useState<History>();
   const { setOpen: openModal, Modal } = useModal();
-  const { setOpenTitleAndMessage, Dialog } = useDialog();
   const { historiesList, lastPage, page, type, setPage, setQuery, setType } =
-    useGetHistories({ setOpenTitleAndMessage });
+    useGetHistories({});
 
   return (
     <main>
-      <Dialog />
       <Banner
         img="admin"
         titleKo="전체 대출/반납 기록"

--- a/src/component/login/Register.tsx
+++ b/src/component/login/Register.tsx
@@ -1,10 +1,10 @@
 import { usePostUsersCreate } from "../../api/users/usePostUsersCreate";
 import { registerRule } from "../../constant/validate";
-import "../../asset/css/Register.css";
 import { ChangeEventHandler, FormEventHandler } from "react";
+import "../../asset/css/Register.css";
 
 const Register = () => {
-  const { registerData, setRegisterData, requestRegister, Dialog } =
+  const { registerData, setRegisterData, requestRegister } =
     usePostUsersCreate();
 
   const validateInput = (value: string, name: string) => {
@@ -51,7 +51,6 @@ const Register = () => {
 
   return (
     <main>
-      <Dialog />
       <section className="banner main-img">
         <div className="main-banner register-banner">
           <div className="register-main">

--- a/src/component/main/Main.tsx
+++ b/src/component/main/Main.tsx
@@ -2,16 +2,13 @@ import MainBanner from "./MainBanner";
 import MainNew from "./MainNew";
 import MainPopular from "./MainPopular";
 import "../../asset/css/Main.css";
-import { useDialog } from "../../hook/useDialog";
 
 const Main = () => {
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
   return (
     <main className="main-wrapper">
-      <Dialog />
       <MainBanner />
-      <MainNew setOpenTitleAndMessage={setOpenTitleAndMessage} />
-      <MainPopular setOpenTitleAndMessage={setOpenTitleAndMessage} />
+      <MainNew />
+      <MainPopular />
     </main>
   );
 };

--- a/src/component/main/MainNew.tsx
+++ b/src/component/main/MainNew.tsx
@@ -3,12 +3,8 @@ import MainNewBookList from "./MainNewBookList";
 import { useGetBooksInfoNew } from "../../api/books/useGetBooksInfoNew";
 import "../../asset/css/MainNew.css";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-const MainNew = ({ setOpenTitleAndMessage }: Props) => {
-  const { bookList } = useGetBooksInfoNew({ setOpenTitleAndMessage });
+const MainNew = () => {
+  const { bookList } = useGetBooksInfoNew();
 
   return (
     <section className="main-new">

--- a/src/component/main/MainPopular.tsx
+++ b/src/component/main/MainPopular.tsx
@@ -5,13 +5,9 @@ import MainPopularSide from "./MainPopularSide";
 import { useGetBooksInfoPopular } from "../../api/books/useGetBooksInfoPopular";
 import "../../asset/css/MainPopular.css";
 
-type Props = {
-  setOpenTitleAndMessage: (title: string, message: string) => void;
-};
-
-const MainPopular = ({ setOpenTitleAndMessage }: Props) => {
+const MainPopular = () => {
   const [centerTop, setCenterTop] = useState(0);
-  const { docs } = useGetBooksInfoPopular({ setOpenTitleAndMessage });
+  const { docs } = useGetBooksInfoPopular();
 
   const left = docs.slice(centerTop - 3, centerTop);
   const center = () => {

--- a/src/component/mypage/EditEmailOrPassword.tsx
+++ b/src/component/mypage/EditEmailOrPassword.tsx
@@ -1,7 +1,7 @@
 import { useState, useMemo, ChangeEventHandler, FormEventHandler } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { useDialog } from "../../hook/useDialog";
 import { usePatchUsersMyupdate } from "../../api/users/usePatchUsersMyupdate";
+import { useNewDialog } from "../../hook/useNewDialog";
 import Image from "../utils/Image";
 import { registerRule } from "../../constant/validate";
 import arrowLeft from "../../asset/img/arrow_left_black.svg";
@@ -32,33 +32,27 @@ function EditEmailOrPassword() {
     setRevision({ ...revision, check: value });
   };
 
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
-
   const { setPatchData } = usePatchUsersMyupdate({
     modeString: modeStringKorean,
-    setOpenTitleAndMessage,
   });
+
+  const { addDialogWithTitleAndMessage } = useNewDialog();
 
   const onSubmitUpdate: FormEventHandler = e => {
     e.preventDefault();
-    if (mode === "pw" && revision.text !== revision.check) {
-      setOpenTitleAndMessage("비밀번호 재입력이 다릅니다.", "");
-      return;
-    }
-    if (!registerRule[modeString]?.validator(revision.text, "")) {
-      setOpenTitleAndMessage(registerRule[modeString].invalidMessage, "");
-      return;
-    }
-    if (!revision.text) {
-      setOpenTitleAndMessage(`${modeStringKorean}를 다시 확인해주세요`, "");
-      return;
-    }
+    let title = "";
+    if (mode === "pw" && revision.text !== revision.check)
+      title = "비밀번호 재입력이 다릅니다.";
+    else if (!registerRule[modeString]?.validator(revision.text, ""))
+      title = registerRule[modeString].invalidMessage;
+    else if (!revision.text) title = `${modeStringKorean}를 다시 확인해주세요`;
+
+    addDialogWithTitleAndMessage(title, title, "");
     setPatchData({ [modeString]: revision.text });
   };
 
   return (
     <div className="mypage-edit">
-      <Dialog />
       <div className="mypage-edit-box">
         <div className="mypage-edit-leftArrow">
           <button type="button" onClick={() => navigate(-1)}>

--- a/src/component/mypage/MyRentInfo/MyRent.tsx
+++ b/src/component/mypage/MyRentInfo/MyRent.tsx
@@ -1,20 +1,13 @@
-import RentHistory from "./RentHistory";
-import { useDialog } from "../../../hook/useDialog";
 import { useGetUsersSearchId } from "../../../api/users/useGetUsersSearchId";
+import RentHistory from "./RentHistory";
 import RentedOrReservedBooks from "./RentedOrReservedBooks";
 import InquireBoxTitle from "../../utils/InquireBoxTitle";
 import Book from "../../../asset/img/admin_icon.svg";
 
 const MyRent = () => {
-  const { setOpenTitleAndMessage: setDialogTitleAndMessage, Dialog } =
-    useDialog();
-
   const user = window.localStorage.getItem("user");
   const userId = user && JSON.parse(user).id;
-  const { userInfo } = useGetUsersSearchId({
-    setDialogTitleAndMessage,
-    userId,
-  });
+  const { userInfo } = useGetUsersSearchId({ userId });
 
   return (
     <>
@@ -43,7 +36,6 @@ const MyRent = () => {
           <RentHistory />
         </div>
       </div>
-      <Dialog />
     </>
   );
 };

--- a/src/component/mypage/MyRentInfo/RentHistory.tsx
+++ b/src/component/mypage/MyRentInfo/RentHistory.tsx
@@ -2,13 +2,10 @@ import Pagination from "../../utils/Pagination";
 import { useGetHistories } from "../../../api/histories/useGetHistories";
 import RentHistoryTable from "./RentHistoryTable";
 import "../../../asset/css/RentHistory.css";
-import { useDialog } from "../../../hook/useDialog";
 
 const RentHistory = () => {
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
   const { historiesList, lastPage, page, setPage } = useGetHistories({
     initWho: "my",
-    setOpenTitleAndMessage,
   });
 
   return (

--- a/src/component/mypage/MyRentInfo/RentHistoryTable.tsx
+++ b/src/component/mypage/MyRentInfo/RentHistoryTable.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useDialog } from "../../../hook/useDialog";
 import { useGetLike } from "../../../api/like/useGetLike";
 import { usePostLike } from "../../../api/like/usePostLike";
 import { useDeleteLike } from "../../../api/like/useDeleteLike";
@@ -15,21 +14,15 @@ type Props = {
 
 const RentHistoryTable = ({ factor }: Props) => {
   const [currentLike, setCurrentLike] = useState(false);
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
   useGetLike({
-    setOpenTitleAndMessage,
     initBookInfoId: factor.bookInfoId,
     setCurrentLike,
   });
-  const { setBookInfoId: setBookInfoIdPost } = usePostLike({
-    setOpenTitleAndMessage,
-  });
+  const { setBookInfoId: setBookInfoIdPost } = usePostLike();
   const postLike = (bookInfoId: number) => {
     setBookInfoIdPost(bookInfoId);
   };
-  const { setBookInfoId: setBookInfoIdDelete } = useDeleteLike({
-    setOpenTitleAndMessage,
-  });
+  const { setBookInfoId: setBookInfoIdDelete } = useDeleteLike();
   const deleteLike = (bookInfoId: number) => {
     setBookInfoIdDelete(bookInfoId);
   };
@@ -46,7 +39,6 @@ const RentHistoryTable = ({ factor }: Props) => {
 
   return (
     <div className="rent_histories__table-list">
-      <Dialog />
       <span className="rent_histories__table_info__date">
         {factor?.createdAt}
       </span>

--- a/src/component/mypage/MyRentInfo/RentedOrReservedBooks.tsx
+++ b/src/component/mypage/MyRentInfo/RentedOrReservedBooks.tsx
@@ -1,4 +1,3 @@
-import { useDialog } from "../../../hook/useDialog";
 import { usePatchReservationsCancel } from "../../../api/reservations/usePatchReservationsCancel";
 import Image from "../../utils/Image";
 import { isNumber } from "../../../util/typeCheck";
@@ -13,17 +12,9 @@ type Props = {
 const RentedOrReservedBooks = ({ componentMode, bookInfoArr }: Props) => {
   if (!bookInfoArr) return null;
 
-  const { setOpen, defaultConfig, setConfig, Dialog, setOpenTitleAndMessage } =
-    useDialog();
-  const { setReservationId } = usePatchReservationsCancel({
-    setOpen,
-    setConfig,
-    defaultConfig,
-    setOpenTitleAndMessage,
-  });
+  const { setReservationId } = usePatchReservationsCancel();
   return (
     <div className="mypage-books_box">
-      <Dialog />
       {bookInfoArr &&
         bookInfoArr.map(bookInfo => (
           <div key={bookInfo.title} className="mypage-books_box-wrapper">

--- a/src/component/mypage/MyReservation.tsx
+++ b/src/component/mypage/MyReservation.tsx
@@ -1,19 +1,12 @@
-import { useDialog } from "../../hook/useDialog";
 import { useGetUsersSearchId } from "../../api/users/useGetUsersSearchId";
 import RentedOrReservedBooks from "./MyRentInfo/RentedOrReservedBooks";
 import InquireBoxTitle from "../utils/InquireBoxTitle";
 import Reserve from "../../asset/img/list-check-solid.svg";
 
 const MyReservation = () => {
-  const { setOpenTitleAndMessage: setDialogTitleAndMessage, Dialog } =
-    useDialog();
-
   const user = window.localStorage.getItem("user");
   const userId = user && JSON.parse(user).id;
-  const { userInfo } = useGetUsersSearchId({
-    setDialogTitleAndMessage,
-    userId,
-  });
+  const { userInfo } = useGetUsersSearchId({ userId });
 
   return (
     <>
@@ -32,7 +25,6 @@ const MyReservation = () => {
           />
         </div>
       </div>
-      <Dialog />
     </>
   );
 };

--- a/src/component/mypage/Mypage.tsx
+++ b/src/component/mypage/Mypage.tsx
@@ -1,23 +1,21 @@
 import { ReactNode, useEffect, useState } from "react";
 import { Link, useSearchParams } from "react-router-dom";
 import { myPageTabList } from "../../constant/tablist";
+import { useTabFocus } from "../../hook/useTabFocus";
+import { useNewDialog } from "../../hook/useNewDialog";
+import { useGetUsersSearchId } from "../../api/users/useGetUsersSearchId";
 import MyRent from "./MyRentInfo/MyRent";
 import MyReservation from "./MyReservation";
 import MyReview from "./MyReview";
-import { useDialog } from "../../hook/useDialog";
-import { useGetUsersSearchId } from "../../api/users/useGetUsersSearchId";
 import ScrollTopButton from "../utils/ScrollTopButton";
 import InquireBoxTitle from "../utils/InquireBoxTitle";
 import getErrorMessage from "../../constant/error";
 import Login from "../../asset/img/login_icon_white.svg";
-import { useTabFocus } from "../../hook/useTabFocus";
 import "../../asset/css/Mypage.css";
 
 const Mypage = () => {
   const { currentTab, changeTab } = useTabFocus(0, myPageTabList);
   const [urlQuery, setUrlQuery] = useSearchParams();
-  const { setOpenTitleAndMessage: setDialogTitleAndMessage, Dialog } =
-    useDialog();
 
   const selectComponent: { [key: string]: ReactNode } = {
     myRent: <MyRent />,
@@ -26,10 +24,7 @@ const Mypage = () => {
   };
   const user = window.localStorage.getItem("user");
   const userId = user && JSON.parse(user).id;
-  const { userInfo } = useGetUsersSearchId({
-    setDialogTitleAndMessage,
-    userId,
-  });
+  const { userInfo } = useGetUsersSearchId({ userId });
   const [deviceMode, setDeviceMode] = useState("desktop");
 
   const convertRoleToStr = (roleInt: number) => {
@@ -45,12 +40,13 @@ const Mypage = () => {
     }
   };
 
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   useEffect(() => {
     const error = urlQuery.get("errorCode");
     if (error) {
       const errorCode = parseInt(error, 10);
       const [title, message] = getErrorMessage(errorCode).split("\r\n");
-      setDialogTitleAndMessage(title, message, () => {
+      addDialogWithTitleAndMessage(title, title, message, () => {
         urlQuery.delete("errorCode");
         setUrlQuery(urlQuery);
       });
@@ -211,7 +207,6 @@ const Mypage = () => {
         </div>
       </section>
       <div>{selectComponent[currentTab]}</div>
-      <Dialog />
     </>
   );
 };

--- a/src/component/rent/Rent.tsx
+++ b/src/component/rent/Rent.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { useDialog } from "../../hook/useDialog";
 import { useModal } from "../../hook/useModal";
 import { rentTabList } from "../../constant/tablist";
 import { Book, User } from "../../type";
@@ -18,7 +17,6 @@ const Rent = () => {
   const [selectedUser, setSelectedUser] = useState<User | null>(null);
   const [selectedBooks, setSelectedBooks] = useState<Book[]>([]);
 
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
   const { Modal, setOpen: openModal, setClose: closeModal } = useModal();
 
   return (
@@ -77,11 +75,9 @@ const Rent = () => {
             setSelectedBooks={setSelectedBooks}
             setSelectedUser={setSelectedUser}
             closeModal={closeModal}
-            setError={setOpenTitleAndMessage}
           />
         </Modal>
       ) : null}
-      <Dialog />
     </main>
   );
 };

--- a/src/component/rent/RentModalBook.tsx
+++ b/src/component/rent/RentModalBook.tsx
@@ -19,7 +19,7 @@ const RentModalBook = ({
 }: Props) => {
   const [isUsingBarcodeReader, setUsingBarcodeReader] = useState(true);
 
-  const { setBookId, Dialog: ErrorDialog } = useGetBooksId({
+  const { setBookId } = useGetBooksId({
     setSelectedBooks,
     closeModal,
   });
@@ -30,7 +30,7 @@ const RentModalBook = ({
     setBookId(bookId);
   };
 
-  const { bookList, lastPage, page, setPage, setQuery, Dialog } =
+  const { bookList, lastPage, page, setPage, setQuery } =
     useGetBooksSearch({ limit: 3 });
 
   return (
@@ -54,8 +54,6 @@ const RentModalBook = ({
           closeModal={closeModal}
         />
       ))}
-      <Dialog />
-      <ErrorDialog />
     </SearchModal>
   );
 };

--- a/src/component/rent/RentModalConfirm.tsx
+++ b/src/component/rent/RentModalConfirm.tsx
@@ -12,7 +12,6 @@ type Props = {
   selectedBooks: Book[];
   setSelectedUser: (user: User) => void;
   setSelectedBooks: React.Dispatch<React.SetStateAction<Book[]>>;
-  setError: (title: string, message: string) => void;
   closeModal: () => void;
 };
 
@@ -21,7 +20,6 @@ const RentModalConfirm = ({
   selectedBooks,
   setSelectedUser,
   setSelectedBooks,
-  setError,
   closeModal,
 }: Props) => {
   const [first, setFirst] = useState("");
@@ -32,7 +30,6 @@ const RentModalConfirm = ({
     selectedUser,
     setSelectedBooks,
     setSelectedUser,
-    setError,
     closeModal,
   });
 

--- a/src/component/rent/RentModalUser.tsx
+++ b/src/component/rent/RentModalUser.tsx
@@ -9,8 +9,9 @@ type Props = {
 };
 
 const RentModalUser = ({ setSelectedUser, closeModal }: Props) => {
-  const { userList, lastPage, page, setPage, setQuery, Dialog } =
-    useGetUsersSearch({ limit: 5 });
+  const { userList, lastPage, page, setPage, setQuery } = useGetUsersSearch({
+    limit: 5,
+  });
 
   return (
     <SearchModal
@@ -21,7 +22,6 @@ const RentModalUser = ({ setSelectedUser, closeModal }: Props) => {
       setQuery={setQuery}
       lastPage={lastPage}
     >
-      <Dialog />
       {userList.map(user => (
         <RentUserList
           key={user.id}

--- a/src/component/reservedloan/ReservedLoan.tsx
+++ b/src/component/reservedloan/ReservedLoan.tsx
@@ -25,12 +25,10 @@ const ReservedLoan = () => {
     setQuery,
     filter,
     setFilter,
-    Dialog,
   } = useGetReservationsSearch();
 
   return (
     <main>
-      <Dialog />
       <Banner img="admin" titleKo="예약 대출" titleEn="BOOK RESERVATION" />
       <Tabs tabList={rentTabList} />
       <section className="reserved-loan-body">

--- a/src/component/reservedloan/ReservedModalContents.tsx
+++ b/src/component/reservedloan/ReservedModalContents.tsx
@@ -1,5 +1,4 @@
 import { FormEventHandler, useState } from "react";
-import { useDialog } from "../../hook/useDialog";
 import { usePostLendings } from "../../api/lendings/usePostLendings";
 import { usePatchReservationsCancel } from "../../api/reservations/usePatchReservationsCancel";
 import Button from "../utils/Button";
@@ -18,21 +17,13 @@ type Props = {
 
 const ReservedModalContents = ({ reservedInfo, closeModal }: Props) => {
   const [remark, setRemark] = useState("");
-  const { Dialog, setOpen, defaultConfig, setConfig, setOpenTitleAndMessage } =
-    useDialog();
 
-  const { setReservationId: cancelReservation } = usePatchReservationsCancel({
-    setOpen,
-    setConfig,
-    defaultConfig,
-    setOpenTitleAndMessage,
-  });
+  const { setReservationId: cancelReservation } = usePatchReservationsCancel();
 
   const { requestLending } = usePostLendings({
     title: reservedInfo?.title,
     userId: reservedInfo?.userId,
     bookId: reservedInfo?.bookId,
-    setOpenTitleAndMessage,
     closeModal,
   });
 
@@ -51,7 +42,6 @@ const ReservedModalContents = ({ reservedInfo, closeModal }: Props) => {
       bookCoverAlt={reservedInfo.title}
       bookCoverImg={reservedInfo.image}
     >
-      <Dialog />
       <TextWithLabel
         wrapperClassName="reserved-modal__book"
         topLabelText="도서정보"

--- a/src/component/return/ReturnBook.tsx
+++ b/src/component/return/ReturnBook.tsx
@@ -7,7 +7,6 @@ import Banner from "../utils/Banner";
 import Pagination from "../utils/Pagination";
 import BarcodeReader from "../utils/BarcodeReader";
 import InquireBoxTitle from "../utils/InquireBoxTitle";
-import { useDialog } from "../../hook/useDialog";
 import { useModal } from "../../hook/useModal";
 import { useGetLendingsSearch } from "../../api/lendings/useGetLendingsSearch";
 import { useGetLendingsSearchId } from "../../api/lendings/useGetLendingsSearchId";
@@ -23,7 +22,6 @@ const ReturnBook = () => {
   const toggleBarcode = () => setUsingBarcodeReader(!isUsingBarcodeReader);
 
   const { setOpen: openModal, setClose: closeModal, Modal } = useModal();
-  const { setOpenTitleAndMessage, Dialog } = useDialog();
 
   const {
     returnBookList,
@@ -33,11 +31,10 @@ const ReturnBook = () => {
     setQuery,
     isSortNew,
     setIsSortNew,
-  } = useGetLendingsSearch({ setOpenTitleAndMessage });
+  } = useGetLendingsSearch();
   // 위의 search api로는 특정 ID검색이 안됨
   const { setQueryId } = useGetLendingsSearchId({
     openModal,
-    setOpenTitleAndMessage,
     setLendingId,
   });
 
@@ -85,13 +82,11 @@ const ReturnBook = () => {
           </div>
         </div>
       </section>
-      <Dialog />
       {lendingId && (
         <Modal>
           <ReturnModalContents
             lendingId={lendingId}
             closeModal={closeModal}
-            setOpenTitleAndMessage={setOpenTitleAndMessage}
           />
         </Modal>
       )}

--- a/src/component/return/ReturnModalContents.tsx
+++ b/src/component/return/ReturnModalContents.tsx
@@ -9,21 +9,15 @@ import { useGetLendingsId } from "../../api/lendings/useGetLendingsId";
 type Props = {
   lendingId: number;
   closeModal: () => void;
-  setOpenTitleAndMessage: (title: string, message: string) => void;
 };
 
-const ReturnModalContents = ({
-  lendingId,
-  closeModal,
-  setOpenTitleAndMessage: setError,
-}: Props) => {
-  const { lendingData } = useGetLendingsId({ lendingId, closeModal, setError });
+const ReturnModalContents = ({ lendingId, closeModal }: Props) => {
+  const { lendingData } = useGetLendingsId({ lendingId, closeModal });
 
   const { condition, setCondition, requestReturn } = usePatchLendingsReturn({
     lendingId,
     title: lendingData?.title || "",
     closeModal,
-    setError,
   });
   if (!lendingData) return null;
 

--- a/src/component/reviewManagement/ReviewManagement.tsx
+++ b/src/component/reviewManagement/ReviewManagement.tsx
@@ -20,7 +20,6 @@ const ReviewManagement = () => {
     setSelectedType,
     reviewList,
     lastPage,
-    Dialog,
   } = useGetReviews();
 
   const setUndefinedReSelected = (newType: string) => {
@@ -29,7 +28,6 @@ const ReviewManagement = () => {
 
   return (
     <main>
-      <Dialog />
       <Banner img="admin" titleKo="리뷰 관리" titleEn="REVIEW MANAGEMENT" />
       <Tabs tabList={otherManagementTabList} />
       <Management

--- a/src/component/reviewManagement/ReviewManagementList.tsx
+++ b/src/component/reviewManagement/ReviewManagementList.tsx
@@ -1,47 +1,36 @@
 import { MouseEventHandler } from "react";
-import { useDialog } from "../../hook/useDialog";
 import { usePatchReviewsId } from "../../api/reviews/usePatchReviewsId";
 import { Review } from "../../type";
 import Edit from "../../asset/img/edit.svg";
 import Image from "../utils/Image";
 import "../../asset/css/ReviewManagementList.css";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   reviewList: Review[];
 };
 
 const ReviewManagementList = ({ reviewList }: Props) => {
-  const { Dialog, setOpenTitleAndMessage, setConfig, defaultConfig, setOpen } =
-    useDialog();
-  const { setReviewId } = usePatchReviewsId({
-    setOpenTitleAndMessage,
-  });
-
+  const { setReviewId } = usePatchReviewsId();
+  const { addConfirmDialog } = useNewDialog();
   const onClick: MouseEventHandler<HTMLButtonElement> = e => {
     const id = parseInt(e.currentTarget.id, 10);
     const { name: content, value } = e.currentTarget;
     const isHidden = value === "hidden";
     const job = isHidden ? "공개" : "비공개";
 
-    setConfig({
-      ...defaultConfig,
-      title: `리뷰를 ${job}하시겠습니까?`,
-      message: `리뷰내용 : ${content}`,
-      numberOfButtons: 2,
-      firstButton: {
-        ...defaultConfig.firstButton,
-        text: `${job}하기`,
-        onClick: () => {
-          setReviewId(id);
-        },
+    addConfirmDialog(
+      "리뷰확인",
+      `리뷰를 ${job}하시겠습니까?`,
+      `리뷰내용 : ${content}`,
+      () => {
+        setReviewId(id);
       },
-    });
-    setOpen();
+    );
   };
 
   return (
     <>
-      <Dialog />
       {reviewList.map(review => (
         <div className="review-management__list__item" key={review.reviewsId}>
           <span className="review-management__list__id">

--- a/src/component/search/Search.tsx
+++ b/src/component/search/Search.tsx
@@ -16,7 +16,7 @@ import "../../asset/css/Search.css";
 
 const Search = () => {
   const myRef = useRef<HTMLDivElement>(null);
-  const { Dialog, bookList, categoryList, lastPage, categoryIndex } =
+  const { bookList, categoryList, lastPage, categoryIndex } =
     useGetBooksInfoSearchUrl();
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const [query, page, sort] = useParseUrlQueryString(searchUrlQueryKeys);
@@ -103,7 +103,6 @@ const Search = () => {
       <section className="wish-book-wraper">
         <WishBook />
       </section>
-      <Dialog />
     </main>
   );
 };

--- a/src/component/subTag/SubTagManagementList.tsx
+++ b/src/component/subTag/SubTagManagementList.tsx
@@ -6,41 +6,33 @@ import Date from "../utils/Date";
 import { Tag } from "../../type/Tag";
 import Tooltip from "../utils/Tooltip";
 import EllipsisedSpan from "../utils/EllipsisedSpan";
-import { useDialog } from "../../hook/useDialog";
 import { usePatchTagsSub } from "../../api/tags/usePatchTagsSub";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type SubTagManagementListProps = {
   tagList: Tag[];
 };
 
 const SubTagManagementList = ({ tagList }: SubTagManagementListProps) => {
-  const { Dialog, setOpenTitleAndMessage, setConfig, defaultConfig, setOpen } =
-    useDialog();
-  const { setParams } = usePatchTagsSub({ setOpenTitleAndMessage });
+  const { setParams } = usePatchTagsSub();
+  const { addConfirmDialog } = useNewDialog();
 
   const confirmChangeVisibility = (e: MouseEvent<HTMLButtonElement>) => {
     const { id, name: content, value } = e.currentTarget;
 
     const isHidden = value === "false";
     const job = isHidden ? "공개" : "비공개";
-    setConfig({
-      ...defaultConfig,
-      title: `태그를 ${job}하시겠습니까?`,
-      message: `태그내용 : ${content}`,
-      numberOfButtons: 2,
-      firstButton: {
-        ...defaultConfig.firstButton,
-        text: `${job}하기`,
-        onClick: () => {
-          setParams({ id: +id, visibility: isHidden ? "public" : "private" });
-        },
+    addConfirmDialog(
+      "태그 수정확인",
+      `태그를 ${job}하시겠습니까?`,
+      `태그내용 : ${content}`,
+      () => {
+        setParams({ id: +id, visibility: isHidden ? "public" : "private" });
       },
-    });
-    setOpen();
+    );
   };
   return (
     <>
-      <Dialog />
       {tagList.map(tag => {
         const isMerged = tag.superContent !== "default";
 

--- a/src/component/superTag/SuperTagMerge.tsx
+++ b/src/component/superTag/SuperTagMerge.tsx
@@ -11,15 +11,13 @@ type SuperTagMergeProps = {
 };
 const SuperTagMerge = ({ book }: SuperTagMergeProps) => {
   const bookInfoId = book.id || book.bookInfoId;
-  const { tagList, addTag, removeTag, Dialog } =
-    useGetTagsBookInfoId(bookInfoId);
+  const { tagList, addTag, removeTag } = useGetTagsBookInfoId(bookInfoId);
 
   const defaultTagList = tagList.filter(i => i.type === "default");
   const superTagList = tagList.filter(i => i.type === "super");
 
   return (
     <div className="super-tag__merge__wrapper">
-      <Dialog />
       <SuperTagMergeCreate bookInfoId={bookInfoId} addTag={addTag} />
       <DragZone>
         <SuperTagMergeDefaultTag

--- a/src/component/superTag/SuperTagMergeAccordion.tsx
+++ b/src/component/superTag/SuperTagMergeAccordion.tsx
@@ -3,12 +3,12 @@ import { useGetTagsSuperTagIdSub } from "../../api/tags/useGetTagsSuperTagIdSub"
 import { useDeleteTagsSuper } from "../../api/tags/useDeleteTagsSuper";
 import { usePatchTagsBookInfoIdMerge } from "../../api/tags/usePatchTagsBookInfoIdMerge";
 import { Tag } from "../../type";
-import { useDialog } from "../../hook/useDialog";
 import Accordion from "../utils/Accordion";
 import SuperTagMergeSubTag from "./SuperTagMergeSubTag";
 import Droppable from "../utils/Droppable";
 import Image from "../utils/Image";
 import TrashIcon from "../../asset/img/trash.svg";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   bookInfoId: number;
@@ -17,22 +17,10 @@ type Props = {
 };
 
 const SuperTagMergeAccordion = ({ bookInfoId, tag, removeTag }: Props) => {
-  const { Dialog, setOpenTitleAndMessage, setConfig, setOpen, defaultConfig } =
-    useDialog();
   const { subTagList, toggleOpened, addSubTag, removeSubTag } =
-    useGetTagsSuperTagIdSub({
-      tagId: tag.id,
-      setOpenTitleAndMessage,
-    });
-  const { deleteTag } = useDeleteTagsSuper({
-    removeTag,
-    setOpenTitleAndMessage,
-  });
-
-  const { setParams } = usePatchTagsBookInfoIdMerge({
-    bookInfoId,
-    setOpenTitleAndMessage,
-  });
+    useGetTagsSuperTagIdSub({ tagId: tag.id });
+  const { deleteTag } = useDeleteTagsSuper({ removeTag });
+  const { setParams } = usePatchTagsBookInfoIdMerge({ bookInfoId });
 
   const addNewListAndMergeIfMoved: DragEventHandler = e => {
     const stringifiedTag = e.dataTransfer.getData("text/plain");
@@ -43,26 +31,16 @@ const SuperTagMergeAccordion = ({ bookInfoId, tag, removeTag }: Props) => {
     }
   };
 
+  const { addConfirmDialog } = useNewDialog();
   const getConfirmThenRemove: MouseEventHandler = e => {
     e.preventDefault();
     e.stopPropagation();
-    setConfig({
-      ...defaultConfig,
-      title: `태그를 삭제하겠습니까?`,
-      message: `태그 내용 : ${tag.content}`,
-      numberOfButtons: 2,
-      firstButton: {
-        ...defaultConfig.firstButton,
-        onClick: () => {
-          deleteTag(tag.id);
-        },
-      },
-    });
-    setOpen();
+    addConfirmDialog("삭제확인", "태그를 삭제하겠습니까?", "", () =>
+      deleteTag(tag.id),
+    );
   };
   return (
     <div className="super-tag__accordion__wrapper">
-      <Dialog />
       <Accordion
         summaryButtonClassName="super-tag__accordion__summary"
         summaryUI={

--- a/src/component/superTag/SuperTagMergeCreate.tsx
+++ b/src/component/superTag/SuperTagMergeCreate.tsx
@@ -3,18 +3,15 @@ import { usePostTagsSuper } from "../../api/tags/usePostTagsSuper";
 import { Tag } from "../../type";
 import Image from "../utils/Image";
 import Arrow from "../../asset/img/arrow_right_black.svg";
-import { useDialog } from "../../hook/useDialog";
 
 type Props = {
   bookInfoId: number;
   addTag: (tag: Tag) => void;
 };
 const SuperTagMergeCreate = ({ bookInfoId, addTag }: Props) => {
-  const { Dialog, setOpenTitleAndMessage } = useDialog();
   const { postSuperTag, newTagName, setNewTagName } = usePostTagsSuper({
     bookInfoId,
     addTag,
-    setOpenTitleAndMessage,
   });
   const onChange: React.ChangeEventHandler<HTMLInputElement> = e => {
     setNewTagName(e.currentTarget.value);
@@ -38,7 +35,6 @@ const SuperTagMergeCreate = ({ bookInfoId, addTag }: Props) => {
           onChange={onChange}
           placeholder="새로운 태그 생성하기"
         />
-        <Dialog />
       </form>
     </div>
   );

--- a/src/component/superTag/SuperTagMergeDefaultTag.tsx
+++ b/src/component/superTag/SuperTagMergeDefaultTag.tsx
@@ -1,5 +1,4 @@
 import { DragEventHandler, useState } from "react";
-import { useDialog } from "../../hook/useDialog";
 import { usePatchTagsBookInfoIdMerge } from "../../api/tags/usePatchTagsBookInfoIdMerge";
 import { Tag } from "../../type";
 import Accordion from "../utils/Accordion";
@@ -25,11 +24,8 @@ const SuperTagMergeDefaultTag = ({
     tag.content.includes(searchInput),
   );
 
-  const { setOpenTitleAndMessage } = useDialog();
-
   const { setParams } = usePatchTagsBookInfoIdMerge({
     bookInfoId,
-    setOpenTitleAndMessage,
   });
 
   const addNewListAndMergeIfMoved: DragEventHandler = e => {

--- a/src/component/superTag/SuperTagSearchBookModal.tsx
+++ b/src/component/superTag/SuperTagSearchBookModal.tsx
@@ -9,12 +9,12 @@ type Props = {
 };
 
 const SuperTagSearchBookModal = ({ setBook }: Props) => {
-  const { bookList, lastPage, page, setPage, setQuery, Dialog } =
-    useGetBooksInfoSearch({ limit: 3 });
+  const { bookList, lastPage, page, setPage, setQuery } = useGetBooksInfoSearch(
+    { limit: 3 },
+  );
 
   return (
     <>
-      <Dialog />
       <Modal isOpen={true} onCloseModal={() => {}}>
         <SearchModal
           className="super-tag-book__search__wrapper"

--- a/src/component/utils/Dialog.tsx
+++ b/src/component/utils/Dialog.tsx
@@ -1,0 +1,70 @@
+import { useState } from "react";
+import { DialogConfig } from "../../type/DialogConfig";
+import Modal from "./Modal";
+import ModalHeader from "./ModalHeader";
+import ModalFooter from "./ModalFooter";
+import "../../asset/css/Dialog.css";
+
+const Dialog = ({
+  title,
+  message,
+  afterClose = () => {},
+  titleEmphasis = "",
+  buttonAlign = "basic",
+  numberOfButtons = 1,
+  firstButton = {
+    text: "확인하기",
+    color: "red",
+  },
+  secondButton = {
+    text: "취소하기",
+    color: "grey",
+  },
+}: DialogConfig) => {
+  const [isOpened, setOpened] = useState(true);
+
+  const closeDialog = () => {
+    if (afterClose) {
+      afterClose();
+    }
+    setOpened(false);
+  };
+
+  if (!isOpened) return null;
+  return (
+    <Modal isOpen={isOpened} onCloseModal={closeDialog}>
+      <ModalHeader
+        title={title}
+        emphasis={titleEmphasis}
+        isWithCloseButton
+        onCloseModal={closeDialog}
+      />
+      <div className="modal__dialog">
+        <p className="modal__dialog__message">{message}</p>
+      </div>
+      <ModalFooter
+        align={buttonAlign}
+        numberOfButtons={numberOfButtons || 1}
+        firstButtonText={firstButton?.text || "확인하기"}
+        firstButtonColor={firstButton?.color || "red"}
+        firstButtonOnClick={() => {
+          if (firstButton.onClick) {
+            firstButton.onClick();
+          }
+          closeDialog();
+        }}
+        isFirstButtonFocusedOnMount
+        secondButtonText={secondButton.text || "취소하기"}
+        secondButtonColor={secondButton.color || "grey"}
+        secondButtonOnClick={() => {
+          if (secondButton.onClick) {
+            secondButton.onClick();
+          }
+          closeDialog();
+        }}
+      />
+    </Modal>
+  );
+};
+
+export default Dialog;

--- a/src/component/utils/HiddenModal.jsx
+++ b/src/component/utils/HiddenModal.jsx
@@ -1,20 +1,22 @@
 import { useEffect } from "react";
-import { useDialog } from "../../hook/useDialog";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 const HiddenModal = () => {
   // 페이지 전환 후 띄워야 하는 모달일 경우(ex./auth) localstorage 이용
-  const { isOpen, Dialog, setOpenTitleAndMessage } = useDialog();
-
+  const { addDialogWithTitleAndMessage } = useNewDialog();
   useEffect(() => {
     const error = JSON.parse(window.localStorage.getItem("error"));
     if (error) {
-      setOpenTitleAndMessage(error?.title, error?.message, () =>
-        window.localStorage.removeItem("error"),
+      addDialogWithTitleAndMessage(
+        error?.title,
+        error?.title,
+        error?.message,
+        () => window.localStorage.removeItem("error"),
       );
     }
   }, []);
 
-  return <>{isOpen && <Dialog />}</>;
+  return <></>;
 };
 
 export default HiddenModal;

--- a/src/component/utils/Portals.tsx
+++ b/src/component/utils/Portals.tsx
@@ -1,0 +1,17 @@
+import { useRecoilValue } from "recoil";
+import { dialogConfigs } from "../../atom/dialogConfigs";
+import Dialog from "./Dialog";
+
+const Portals = () => {
+  const dialogs = useRecoilValue(dialogConfigs);
+
+  return (
+    <>
+      {dialogs.map(config => (
+        <Dialog {...config} />
+      ))}
+    </>
+  );
+};
+
+export default Portals;

--- a/src/hook/useApi.ts
+++ b/src/hook/useApi.ts
@@ -1,18 +1,11 @@
 import { useCallback } from "react";
+import { useNewDialog } from "./useNewDialog";
 import axiosPromise from "../util/axios";
-import getErrorMessage from "../constant/error";
-import { useDialog } from "./useDialog";
 
 type Method = "get" | "post" | "put" | "patch" | "delete";
 
 export const useApi = (method: Method, url: string, data?: unknown) => {
-  const { setOpenTitleAndMessage: setError, Dialog } = useDialog();
-
-  const errorDialog = (error: any) => {
-    const errorCode = error?.response?.data?.errorCode;
-    const [title, message] = getErrorMessage(errorCode).split("\r\n");
-    setError(title, errorCode ? message : `${message}\r\n${error?.message}`);
-  };
+  const { addErrorDialog } = useNewDialog();
 
   const request = useCallback(
     (resolve: (response: any) => void, reject?: (error: any) => void) => {
@@ -21,12 +14,13 @@ export const useApi = (method: Method, url: string, data?: unknown) => {
           resolve(response);
         })
         ?.catch(error => {
+          // 직접 정의한 reject함수가 없으면 기본적인 에러 알림 다이얼로그 호출
           if (reject) reject(error);
-          else errorDialog(error);
+          else addErrorDialog(error);
         });
     },
     [method, url, data],
   );
 
-  return { request, setError, Dialog };
+  return { request };
 };

--- a/src/hook/useNewDialog.ts
+++ b/src/hook/useNewDialog.ts
@@ -1,18 +1,18 @@
 import { useSetRecoilState } from "recoil";
 import { dialogConfigs } from "../atom/dialogConfigs";
 import { DialogConfig } from "../type/DialogConfig";
+import getErrorMessage from "../constant/error";
 
 export const useNewDialog = () => {
   const setDialogSettings = useSetRecoilState(dialogConfigs);
-
   const removeDialog = (id: number) => {
     setDialogSettings(prev => prev.filter(dialog => dialog.id !== id));
   };
 
-  const addDialog = (
-    key: string,
-    dialogConfig: Omit<DialogConfig, "id" | "key">,
-  ) => {
+  /** 세부적인 조절이 가능한 기본 함수
+   * @param dialogConfig 다이얼로그 설정
+   */
+  const addDialogWithConfig = (dialogConfig: Omit<DialogConfig, "id">) => {
     const id = Date.now();
     setDialogSettings(prev => [
       ...prev,
@@ -22,11 +22,70 @@ export const useNewDialog = () => {
           dialogConfig.afterClose?.();
           removeDialog(id);
         },
-        key,
         id,
       },
     ]);
   };
 
-  return { addDialog };
+  /** 간단하게 다이얼로그 호출
+   * @param title  제목
+   * @param message 내용
+   * @param afterClose 다이얼로그가 닫힌 후 실행할 함수
+   */
+  const addDialogWithTitleAndMessage = (
+    title: string,
+    message: string,
+    afterClose?: () => void,
+  ) => {
+    addDialogWithConfig({
+      title,
+      message,
+      afterClose,
+    });
+  };
+
+  /** 확인 요청용 다이얼로그 호출
+   * @param title  제목
+   * @param message 내용
+   * @param onConfirm 확인 버튼을 클릭했을 때만 실행할 함수, 취소 버튼 등 다른 버튼으로 닫히면 실행되지 않음
+   */
+  const addConfirmDialog = (
+    title: string,
+    message: string,
+    onConfirm: () => void,
+  ) => {
+    addDialogWithConfig({
+      title,
+      message,
+      firstButton: {
+        onClick: onConfirm,
+      },
+    });
+  };
+
+  /** 에러 상황 알림용 다이얼로그 호출
+   * @param error 에러 정보를 담은 객체
+   * @param afterClose 다이얼로그가 닫힌 후 실행할 함수 (optional)
+   */
+  const addErrorDialog = (
+    error: any,
+    afterClose?: (errorCode: number) => void,
+  ) => {
+    const errorCode = error?.response?.data?.errorCode;
+    const [title, message] = getErrorMessage(errorCode).split("\r\n");
+    addDialogWithTitleAndMessage(
+      title,
+      errorCode ? message : message + "\n" + error.message,
+      () => {
+        if (afterClose && errorCode) afterClose(errorCode);
+      },
+    );
+  };
+
+  return {
+    addDialogWithConfig,
+    addDialogWithTitleAndMessage,
+    addConfirmDialog,
+    addErrorDialog,
+  };
 };

--- a/src/hook/useNewDialog.ts
+++ b/src/hook/useNewDialog.ts
@@ -10,34 +10,45 @@ export const useNewDialog = () => {
   };
 
   /** 세부적인 조절이 가능한 기본 함수
+   * @param key 다이얼로그를 구분할 키, 같은 키로 이미 열린 다이얼로그가 있으면 추가되지 않음
    * @param dialogConfig 다이얼로그 설정
    */
-  const addDialogWithConfig = (dialogConfig: Omit<DialogConfig, "id">) => {
+  const addDialogWithConfig = (
+    key: string,
+    dialogConfig: Omit<DialogConfig, "id" | "key">,
+  ) => {
     const id = Date.now();
-    setDialogSettings(prev => [
-      ...prev,
-      {
-        ...dialogConfig,
-        afterClose: () => {
-          dialogConfig.afterClose?.();
-          removeDialog(id);
+    setDialogSettings(prev => {
+      const isDuplicated = prev.some(config => config.key === key);
+      if (isDuplicated) return prev;
+      return [
+        ...prev,
+        {
+          ...dialogConfig,
+          afterClose: () => {
+            dialogConfig.afterClose?.();
+            removeDialog(id);
+          },
+          key,
+          id,
         },
-        id,
-      },
-    ]);
+      ];
+    });
   };
 
   /** 간단하게 다이얼로그 호출
+   * @param key 다이얼로그를 구분할 키, 같은 키로 이미 열린 다이얼로그가 있으면 추가되지 않음
    * @param title  제목
    * @param message 내용
    * @param afterClose 다이얼로그가 닫힌 후 실행할 함수
    */
   const addDialogWithTitleAndMessage = (
+    key: string,
     title: string,
     message: string,
     afterClose?: () => void,
   ) => {
-    addDialogWithConfig({
+    addDialogWithConfig(key, {
       title,
       message,
       afterClose,
@@ -45,16 +56,18 @@ export const useNewDialog = () => {
   };
 
   /** 확인 요청용 다이얼로그 호출
+   * @param key 다이얼로그를 구분할 키, 같은 키로 이미 열린 다이얼로그가 있으면 추가되지 않음
    * @param title  제목
    * @param message 내용
    * @param onConfirm 확인 버튼을 클릭했을 때만 실행할 함수, 취소 버튼 등 다른 버튼으로 닫히면 실행되지 않음
    */
   const addConfirmDialog = (
+    key: string,
     title: string,
     message: string,
     onConfirm: () => void,
   ) => {
-    addDialogWithConfig({
+    addDialogWithConfig(key, {
       title,
       message,
       firstButton: {
@@ -74,6 +87,7 @@ export const useNewDialog = () => {
     const errorCode = error?.response?.data?.errorCode;
     const [title, message] = getErrorMessage(errorCode).split("\r\n");
     addDialogWithTitleAndMessage(
+      title, // 같은 오류메세지를 여러번 띄우는 것을 방지하기 위해 title을 key로 사용
       title,
       errorCode ? message : message + "\n" + error.message,
       () => {

--- a/src/hook/useNewDialog.ts
+++ b/src/hook/useNewDialog.ts
@@ -76,7 +76,7 @@ export const useNewDialog = () => {
     });
   };
 
-  /** 에러 상황 알림용 다이얼로그 호출
+  /** 에러 상황 알림용 다이얼로그 호출, useApi 훅에서 기본으로 활용됨
    * @param error 에러 정보를 담은 객체
    * @param afterClose 다이얼로그가 닫힌 후 실행할 함수 (optional)
    */

--- a/src/hook/useNewDialog.ts
+++ b/src/hook/useNewDialog.ts
@@ -1,0 +1,32 @@
+import { useSetRecoilState } from "recoil";
+import { dialogConfigs } from "../atom/dialogConfigs";
+import { DialogConfig } from "../type/DialogConfig";
+
+export const useNewDialog = () => {
+  const setDialogSettings = useSetRecoilState(dialogConfigs);
+
+  const removeDialog = (id: number) => {
+    setDialogSettings(prev => prev.filter(dialog => dialog.id !== id));
+  };
+
+  const addDialog = (
+    key: string,
+    dialogConfig: Omit<DialogConfig, "id" | "key">,
+  ) => {
+    const id = Date.now();
+    setDialogSettings(prev => [
+      ...prev,
+      {
+        ...dialogConfig,
+        afterClose: () => {
+          dialogConfig.afterClose?.();
+          removeDialog(id);
+        },
+        key,
+        id,
+      },
+    ]);
+  };
+
+  return { addDialog };
+};

--- a/src/type/DialogConfig.ts
+++ b/src/type/DialogConfig.ts
@@ -1,0 +1,20 @@
+export type DialogConfig = {
+  id: number;
+  key: string;
+  title: string;
+  message: string;
+  titleEmphasis?: string;
+  buttonAlign?: string;
+  numberOfButtons?: number;
+  firstButton?: {
+    text?: string;
+    color?: string;
+    onClick?: () => void;
+  };
+  secondButton?: {
+    text?: string;
+    color?: string;
+    onClick?: () => void;
+  };
+  afterClose?: () => void;
+};

--- a/src/type/DialogConfig.ts
+++ b/src/type/DialogConfig.ts
@@ -1,6 +1,5 @@
 export type DialogConfig = {
   id: number;
-  key: string;
   title: string;
   message: string;
   titleEmphasis?: string;

--- a/src/type/DialogConfig.ts
+++ b/src/type/DialogConfig.ts
@@ -1,5 +1,6 @@
 export type DialogConfig = {
   id: number;
+  key: string;
   title: string;
   message: string;
   titleEmphasis?: string;


### PR DESCRIPTION
# 개요
다이얼로그 변경


# 목적
다이얼로그 제어함수 선언과 호출 시점이 달라 매번 인자로 넘겨줘야하는 문제 해결

# 비교
## 기존 useDialog
호출하는 컴포넌트에 열고 닫기 위한 상태를 추가하고 
기본 설정과 연결된 다이얼로그 컴포넌트와 그 제어함수를 반환하는 훅

### 사용방법
반환된 컴포넌트를 심어두고 노출이 필요한 순간에 제어함수를 호출하여 사용

### 한계
- 상태가 추가되기 때문에 다이얼로그로 인한 리랜더링 오류 가능성 있음 (상태 대비 자식 컴포넌트에서 호출될 경우)
- 다이얼로그 컴포넌트를 미리 심어두지 않을 경우 제어함수 호출을 하도 반영이 되지 않음
- 상황에 따라 다른 다이얼로그를 띄우려면 여러 컴포넌트를 심어두거나 함수를 전달해야 함



## useNewDialog
새로운 다이얼로그를 추가할 수 있는 함수 반환
다이얼로그 설정은 전역으로 관리되고 열고 닫기 위한 상태는 Portals 하위 트리에 추가됨

### 사용방법
필요한 순간에 제어함수 선언 및 호출

### 한계 및 그에 대한 대비
- 설정 목록이 전역으로 저장됨, 리랜더링의 취약점 -> useNewDialog가 호출되는 부분은 상태를 구독하지 않고 수정만 함
  - recoil의 useSetRecoilState 사용 
  https://recoiljs.org/docs/api-reference/core/useSetRecoilState

- fixes #455


### 기타 참고사항
수정사항 파악을 위해 branch 473 과 비교하도록 설정해두었습니다
머지는 base 수정후 진행할 예정입니다.

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
