### PR TITLE
fix: 도서와 유저 선택후 대출하기 버튼이 눌리지 않는 문제 해결

### DIFF
--- a/src/component/rent/RentConfirm.tsx
+++ b/src/component/rent/RentConfirm.tsx
@@ -8,6 +8,11 @@ type Props = {
 };
 
 const RentConfirm = ({ selectedUser, selectedBooks, openModal }: Props) => {
+  const isLendable =
+    selectedUser &&
+    !selectedUser.isPenalty &&
+    selectedBooks.length > 0 &&
+    2 - selectedUser.lendings.length >= selectedBooks.length;
   return (
     <section className="rent__confirm-button">
       <div className="rent__confirm-button__text font-16 color-a4">
@@ -21,20 +26,10 @@ const RentConfirm = ({ selectedUser, selectedBooks, openModal }: Props) => {
       </div>
       <button
         className={`rent__confirm-button__button ${
-          selectedUser &&
-          !selectedUser.isPenalty &&
-          selectedBooks.length > 0 &&
-          2 - selectedUser.lendings.length >= selectedBooks.length
-            ? "red"
-            : "black"
+          isLendable ? "red" : "black"
         }-button color-ff`}
         type="button"
-        disabled={
-          selectedUser === null ||
-          selectedUser.isPenalty ||
-          selectedBooks.length == 0 ||
-          2 - selectedUser.lendings.length >= selectedBooks.length
-        }
+        disabled={!isLendable}
         onClick={openModal}
       >
         도서 대출하기


### PR DESCRIPTION
# 개요
대출이 가능한 상태라서 버튼 색이 변했는데도 눌리지 않던 문제 해결

- fixes #485

### 변경사항
- 대출하기 버튼 색변경과 disabled 로직 통일

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
