### PR TITLE
refactor: 리뷰 리팩토링 및 UI 오류해결

### DIFF
--- a/src/api/bookInfo/useGetBookInfoReviews.ts
+++ b/src/api/bookInfo/useGetBookInfoReviews.ts
@@ -1,0 +1,36 @@
+import { useRef, useState } from "react";
+import { Review } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
+import axiosPromise from "../../util/axios";
+
+export const useGetBookInfoReviews = (bookInfoId: number) => {
+  const [reviewList, setReviewList] = useState<Review[]>([]);
+  const lastReviewId = useRef<number>();
+  const isAllFetched = useRef(false);
+
+  const { addErrorDialog } = useNewDialog();
+
+  const saveList = (response: any) => {
+    const newReviews = response.data.items;
+    const meta = response.data.meta;
+    setReviewList(prev => [...prev, ...newReviews]);
+    if (meta.finalReviewsId) {
+      lastReviewId.current = meta.finalReviewsId;
+    }
+    isAllFetched.current = meta.finalPage;
+  };
+
+  const fetch = () => {
+    axiosPromise("get", `/book-info/${bookInfoId}/reviews`, {
+      reviewsId: lastReviewId.current,
+      limit: 5,
+    })
+      .then(saveList)
+      .catch(addErrorDialog);
+  };
+
+  const deleteReviewById = (id: number) => {
+    setReviewList(prev => prev.filter(review => review.reviewsId !== id));
+  };
+  return { fetch, isAllFetched, reviewList, deleteReviewById };
+};

--- a/src/api/reviews/useDeleteReviewsReviewsId.ts
+++ b/src/api/reviews/useDeleteReviewsReviewsId.ts
@@ -1,0 +1,8 @@
+import axiosPromise from "../../util/axios";
+
+export const useDeleteReviewsReviewsId = () => {
+  const requestToDelete = (reviewsId: number) =>
+    axiosPromise("delete", `/reviews/${reviewsId}`);
+
+  return { requestToDelete };
+};

--- a/src/api/reviews/usePostReview.ts
+++ b/src/api/reviews/usePostReview.ts
@@ -1,41 +1,24 @@
-import { useEffect, useState } from "react";
-import { useApi } from "../../hook/useApi";
+import { useState } from "react";
+
 import { useNewDialog } from "../../hook/useNewDialog";
+import axiosPromise from "../../util/axios";
 
 type Props = {
   bookInfoId: number;
-  changeTab: (tab: number) => void;
+  resetTab: () => void;
 };
 
-export const usePostReview = ({ bookInfoId, changeTab }: Props) => {
-  const checkLogin = JSON.parse(window.localStorage.getItem("user") || "{}");
+export const usePostReview = ({ bookInfoId, resetTab }: Props) => {
   const [content, setContent] = useState("");
-  const { request } = useApi("post", "/reviews", {
-    bookInfoId,
-    content,
-  });
 
-  const refineResponse = () => {
-    changeTab(0);
-  };
-  const { addDialogWithTitleAndMessage } = useNewDialog();
+  const { addErrorDialog } = useNewDialog();
 
-  const displayError = () => {
-    const title =
-      checkLogin === null
-        ? "로그인 후 입력해주세요."
-        : "10자 이상 420자 이하로 입력해주세요.";
-    addDialogWithTitleAndMessage(title, title, "");
-  };
-
-  useEffect(() => {
-    const req = () => {
-      if (content !== "") {
-        request(refineResponse, displayError);
-      }
-    };
-    req();
-  }, [content]);
-
-  return { setContent };
+  const request = () =>
+    axiosPromise("post", "/reviews", {
+      bookInfoId,
+      content,
+    })
+      .then(resetTab)
+      .catch(addErrorDialog);
+  return { content, setContent, request };
 };

--- a/src/api/reviews/usePostReview.ts
+++ b/src/api/reviews/usePostReview.ts
@@ -11,14 +11,20 @@ type Props = {
 export const usePostReview = ({ bookInfoId, resetTab }: Props) => {
   const [content, setContent] = useState("");
 
-  const { addErrorDialog } = useNewDialog();
+  const { addDialogWithTitleAndMessage, addErrorDialog } = useNewDialog();
+
+  const displaySuccessAndResetTab = () => {
+    const title = "성공적으로 등록되었습니다";
+    addDialogWithTitleAndMessage(title, title, "", resetTab);
+  };
 
   const request = () =>
     axiosPromise("post", "/reviews", {
       bookInfoId,
       content,
     })
-      .then(resetTab)
+      .then(displaySuccessAndResetTab)
       .catch(addErrorDialog);
+
   return { content, setContent, request };
 };

--- a/src/api/reviews/usePutReviewsReviewsId.ts
+++ b/src/api/reviews/usePutReviewsReviewsId.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import axiosPromise from "../../util/axios";
+import { useNewDialog } from "../../hook/useNewDialog";
+
+type Props = {
+  reviewsId: number;
+  initialContent: string;
+  finishEditMode: () => void;
+};
+
+export const usePutReviewsReviewsId = ({
+  reviewsId,
+  initialContent,
+  finishEditMode,
+}: Props) => {
+  const [content, setContent] = useState(initialContent);
+
+  const { addErrorDialog } = useNewDialog();
+  
+  const request = () => {
+    axiosPromise("put", `/reviews/${reviewsId}`, { content })
+      .then(finishEditMode)
+      .catch(addErrorDialog);
+  };
+
+  return {
+    content,
+    setContent,
+    request,
+  };
+};

--- a/src/asset/css/Review.css
+++ b/src/asset/css/Review.css
@@ -6,6 +6,7 @@
   background-color: #e8e8e8;
   padding: 4rem 6rem;
   margin: 3rem 0 0 0;
+  font-size: 1.2rem;
 }
 
 .showReview__my-review-box {
@@ -15,6 +16,7 @@
   border-radius: 2rem;
   background-color: #e8e8e8;
   padding: 2rem 4rem;
+  font-size: 1.2rem;
 }
 
 .do-review__review-box {
@@ -68,28 +70,33 @@
   height: 3rem;
 }
 
-.review-info > span {
+.review-day {
   display: block;
 }
 
+.reviewer-name {
+  display: none;
+}
+
+.reviewer-name.book {
+  display: block;
+  font-weight: bold;
+}
 .review-content {
   width: 70%;
   white-space: break-spaces;
   padding: 0rem 3.5rem 0rem 3.5rem;
 }
 
-.review-content-book-title {
-  margin-bottom: 1rem;
+.review-content-book-title.book {
+  display: none;
 }
 
-.review-content-fix-area {
-  width: 95%;
-  min-height: 7rem;
-  padding: 1rem;
-  border: none;
-  resize: none;
-  border-radius: 0.5rem;
-  background-color: white;
+.review-content-book-title {
+  display: block;
+  margin-bottom: 1rem;
+  font-size: 1.4rem;
+  font-weight: bold;
 }
 
 .review-content-area {
@@ -98,6 +105,12 @@
   border: none;
   border-radius: 0.5rem;
   resize: none;
+}
+
+.review-content-area.edit {
+  width: 95%;
+  padding: 1rem;
+  background-color: white;
 }
 
 .review-manage:before {
@@ -113,6 +126,10 @@
   width: 15%;
   padding-left: 5rem;
   position: relative;
+}
+
+.review-manage.hidden {
+  display: none;
 }
 
 .review-manage__fix-buttons > button {
@@ -144,8 +161,8 @@
 }
 
 .review-manage__button-img {
-    margin: 0 0 -0.15rem -3rem;
-    width: 1.1rem;
+  margin: 0 0 -0.15rem -3rem;
+  width: 1.1rem;
 }
 
 .no-review {
@@ -191,6 +208,12 @@
     width: 100%;
   }
 
+  .review-manage.hidden {
+    display: none;
+  }
+  .review-manage.visible {
+    display: block;
+  }
   .review-content-area {
     width: 100%;
     min-height: 0rem;

--- a/src/component/book/review/PostReview.tsx
+++ b/src/component/book/review/PostReview.tsx
@@ -1,68 +1,59 @@
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  ReactNode,
-  useState,
-} from "react";
+import { FormEventHandler } from "react";
 import "../../../asset/css/Review.css";
 import Button from "../../utils/Button";
 import { useNewDialog } from "../../../hook/useNewDialog";
 import { useRecoilValue } from "recoil";
 import userState from "../../../atom/userState";
+import { usePostReview } from "../../../api/reviews/usePostReview";
 
 type Props = {
-  onClickPost: (post: string) => void;
+  bookInfoId: number;
+  resetTab: () => void;
 };
 
-const PostReview = ({ onClickPost }: Props) => {
-  const [content, setContent] = useState("");
-  const checkLogin = useRecoilValue(userState);
-  const checkValidUser = () => {
-    const user = checkLogin;
-    if (user) {
-      if (user.userName === user.email) {
-        return false;
-      }
-    }
-    return true;
-  };
+const PostReview = ({ bookInfoId, resetTab }: Props) => {
+  const { content, setContent, request } = usePostReview({
+    bookInfoId: +bookInfoId,
+    resetTab,
+  });
 
-  const onChange: ChangeEventHandler<HTMLTextAreaElement> = e => {
-    setContent(e.target.value);
-  };
-
+  const user = useRecoilValue(userState);
+  const hasPermissionToPostReview = user && user.userName !== user.email; // 인증된 유저는 이메일과 다른 닉네임을 가짐
+  const isValidLength = content.length >= 10 && content.length <= 420;
   const { addDialogWithTitleAndMessage, addConfirmDialog } = useNewDialog();
-  const submitReview = () => {
-    const validUser = checkValidUser();
-    if (validUser === false) {
-      const title = "42 인증 후 리뷰 등록이 가능합니다.";
-      addDialogWithTitleAndMessage(title, title, "");
+
+  const postReviewOrDisplayError: FormEventHandler = e => {
+    e.preventDefault();
+    if (hasPermissionToPostReview && isValidLength) {
+      addConfirmDialog(
+        `${content} 리뷰등록 확인`,
+        "리뷰를 등록하시겠습니까?",
+        "",
+        request,
+      );
       return;
     }
-    onClickPost(content);
-  };
+    const title = !hasPermissionToPostReview
+      ? "42 인증 후 리뷰 등록이 가능합니다."
+      : "10자 이상 420자 이하로 입력해주세요.";
 
-  const onSubmitHandler: FormEventHandler = e => {
-    e.preventDefault();
-    addConfirmDialog(
-      `${content} 리뷰등록 확인`,
-      "리뷰를 등록하시겠습니까?",
-      "",
-      submitReview,
-    );
+    addDialogWithTitleAndMessage(title, title, "");
   };
 
   return (
     <div className="do-review__review-box">
-      <form className="do-review__review-form" onSubmit={onSubmitHandler}>
+      <form
+        className="do-review__review-form"
+        onSubmit={postReviewOrDisplayError}
+      >
         <textarea
           className="review-area font-12"
           value={content}
-          onChange={onChange}
+          onChange={e => setContent(e.target.value)}
           maxLength={420}
           required
           placeholder={
-            checkLogin
+            user
               ? "10자 이상 420자 이내로 입력해주세요."
               : "로그인 후 리뷰 등록이 가능합니다."
           }

--- a/src/component/book/review/PostReview.tsx
+++ b/src/component/book/review/PostReview.tsx
@@ -7,6 +7,8 @@ import {
 import "../../../asset/css/Review.css";
 import Button from "../../utils/Button";
 import { useNewDialog } from "../../../hook/useNewDialog";
+import { useRecoilValue } from "recoil";
+import userState from "../../../atom/userState";
 
 type Props = {
   onClickPost: (post: string) => void;
@@ -14,9 +16,9 @@ type Props = {
 
 const PostReview = ({ onClickPost }: Props) => {
   const [content, setContent] = useState("");
-  const checkLogin = JSON.parse(window.localStorage.getItem("user") || "{}");
+  const checkLogin = useRecoilValue(userState);
   const checkValidUser = () => {
-    const user = JSON.parse(window.localStorage.getItem("user") || "{}");
+    const user = checkLogin;
     if (user) {
       if (user.userName === user.email) {
         return false;

--- a/src/component/book/review/Review.tsx
+++ b/src/component/book/review/Review.tsx
@@ -37,7 +37,7 @@ const Review = ({ bookInfoId }: Props) => {
       <div className="tabs-line" />
       <div className="review-list">
         {currentTab === "showReviews" ? (
-          <ShowReviews bookInfoId={+bookInfoId} type="bookReviews" />
+          <ShowReviews bookInfoId={+bookInfoId} />
         ) : (
           <PostReview onClickPost={setContent} />
         )}

--- a/src/component/book/review/Review.tsx
+++ b/src/component/book/review/Review.tsx
@@ -2,7 +2,6 @@ import { reviewTabList } from "../../../constant/tablist";
 import PostReview from "./PostReview";
 import ShowReviews from "./ShowReviews";
 import { useTabFocus } from "../../../hook/useTabFocus";
-import { usePostReview } from "../../../api/reviews/usePostReview";
 import "../../../asset/css/Tabs.css";
 import "../../../asset/css/Review.css";
 
@@ -12,10 +11,7 @@ type Props = {
 
 const Review = ({ bookInfoId }: Props) => {
   const { currentTab, changeTab } = useTabFocus(0, reviewTabList);
-  const { setContent } = usePostReview({
-    bookInfoId: +bookInfoId,
-    changeTab,
-  });
+  const resetTab = () => changeTab(0);
 
   return (
     <>
@@ -39,7 +35,7 @@ const Review = ({ bookInfoId }: Props) => {
         {currentTab === "showReviews" ? (
           <ShowReviews bookInfoId={+bookInfoId} />
         ) : (
-          <PostReview onClickPost={setContent} />
+          <PostReview bookInfoId={+bookInfoId} resetTab={resetTab} />
         )}
       </div>
     </>

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -4,6 +4,7 @@ import axiosPromise from "../../../util/axios";
 import { useGetBookInfoReviews } from "../../../api/bookInfo/useGetBookInfoReviews";
 import "../../../asset/css/Tabs.css";
 import "../../../asset/css/Review.css";
+import { useDeleteReviewsReviewsId } from "../../../api/reviews/useDeleteReviewsReviewsId";
 
 type Props = {
   bookInfoId: number;
@@ -14,10 +15,11 @@ const ShowReviews = ({ bookInfoId }: Props) => {
 
   const { reviewList, fetch, isAllFetched, deleteReviewById } =
     useGetBookInfoReviews(bookInfoId);
-
+  const { requestToDelete } = useDeleteReviewsReviewsId();
+  
   const deleteReview = (reviewsId: number) => {
     deleteReviewById(reviewsId);
-    axiosPromise("delete", `/reviews/${reviewsId}`);
+    requestToDelete;
   };
 
   useEffect(() => {

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -13,8 +13,6 @@ type Props = {
 const ShowReviews = ({ bookInfoId, type }: Props) => {
   const triggerElementForInfiniteScroll = useRef<HTMLDivElement>(null);
 
-  const checkLogin = JSON.parse(window.localStorage.getItem("user") || "{}");
-
   const { reviewList, fetch, isAllFetched, deleteReviewById } =
     useGetBookInfoReviews(bookInfoId);
 
@@ -45,9 +43,6 @@ const ShowReviews = ({ bookInfoId, type }: Props) => {
         <HandleReview
           key={review.reviewsId}
           data={review}
-          nickname={review.nickname}
-          createdAt={review.createdAt}
-          checkLogin={checkLogin}
           type={type}
           onClickDel={deleteReview}
         />

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -7,10 +7,9 @@ import "../../../asset/css/Review.css";
 
 type Props = {
   bookInfoId: number;
-  type: string;
 };
 
-const ShowReviews = ({ bookInfoId, type }: Props) => {
+const ShowReviews = ({ bookInfoId }: Props) => {
   const triggerElementForInfiniteScroll = useRef<HTMLDivElement>(null);
 
   const { reviewList, fetch, isAllFetched, deleteReviewById } =
@@ -42,9 +41,9 @@ const ShowReviews = ({ bookInfoId, type }: Props) => {
       {reviewList.map(review => (
         <HandleReview
           key={review.reviewsId}
-          data={review}
-          type={type}
-          onClickDel={deleteReview}
+          review={review}
+          type="book"
+          deleteReview={deleteReview}
         />
       ))}
       {reviewList.length === 0 ? (

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -1,5 +1,5 @@
 import { useRef, useEffect } from "react";
-import HandleReview from "./HandleReview";
+import HandleReview from "../../utils/HandleReview";
 import axiosPromise from "../../../util/axios";
 import { useGetBookInfoReviews } from "../../../api/bookInfo/useGetBookInfoReviews";
 import "../../../asset/css/Tabs.css";

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -52,23 +52,22 @@ const ShowReviews = ({ bookInfoId, type }: Props) => {
 
   return (
     <>
-      {postReviews.length ? (
-        postReviews.map(review => (
-          <HandleReview
-            key={review.reviewsId}
-            data={review}
-            nickname={review.nickname}
-            createdAt={review.createdAt}
-            checkLogin={checkLogin}
-            type={type}
-            onClickDel={deleteReview}
-          />
-        ))
-      ) : (
+      {postReviews.map(review => (
+        <HandleReview
+          key={review.reviewsId}
+          data={review}
+          nickname={review.nickname}
+          createdAt={review.createdAt}
+          checkLogin={checkLogin}
+          type={type}
+          onClickDel={deleteReview}
+        />
+      ))}
+      {postReviews.length === 0 ? (
         <div className="no-review color-54">
           <span className="font-18">첫 번째 리뷰를 남겨주세요!</span>
         </div>
-      )}
+      ) : null}
       <div ref={observeReviewList} />
     </>
   );

--- a/src/component/book/review/ShowReviews.tsx
+++ b/src/component/book/review/ShowReviews.tsx
@@ -32,6 +32,11 @@ const ShowReviews = ({ bookInfoId, type }: Props) => {
 
     if (triggerElementForInfiniteScroll.current)
       io.observe(triggerElementForInfiniteScroll.current); // 트리거 엘리먼트 관찰 시작
+
+    return () => {
+      // 트리거 엘리먼트 관찰 종료
+      io.disconnect();
+    };
   }, []);
 
   return (

--- a/src/component/mypage/MyReview.tsx
+++ b/src/component/mypage/MyReview.tsx
@@ -6,11 +6,7 @@ import Pagination from "../utils/Pagination";
 import { useGetMyReviewInfo } from "../../api/reviews/useGetMyReviewInfo";
 import "../../asset/css/MyReview.css";
 
-type Props = {
-  type: string;
-};
-
-const MyReview = ({ type }: Props) => {
+const MyReview = () => {
   const { page, setPage, lastPage, reviewList, setReviewList } =
     useGetMyReviewInfo();
 
@@ -35,9 +31,9 @@ const MyReview = ({ type }: Props) => {
             {reviewList.map(review => (
               <HandleReview
                 key={review.reviewsId}
-                data={review}
-                type={type}
-                onClickDel={deleteReview}
+                review={review}
+                type="my"
+                deleteReview={deleteReview}
               />
             ))}
           </div>

--- a/src/component/mypage/MyReview.tsx
+++ b/src/component/mypage/MyReview.tsx
@@ -1,6 +1,6 @@
 import InquireBoxTitle from "../utils/InquireBoxTitle";
 import Reserve from "../../asset/img/list-check-solid.svg";
-import HandleReview from "../book/review/HandleReview";
+import HandleReview from "../utils/HandleReview";
 import axiosPromise from "../../util/axios";
 import Pagination from "../utils/Pagination";
 import { useGetMyReviewInfo } from "../../api/reviews/useGetMyReviewInfo";

--- a/src/component/mypage/MyReview.tsx
+++ b/src/component/mypage/MyReview.tsx
@@ -11,7 +11,6 @@ type Props = {
 };
 
 const MyReview = ({ type }: Props) => {
-  const checkLogin = window.localStorage.getItem("user");
   const { page, setPage, lastPage, reviewList, setReviewList } =
     useGetMyReviewInfo();
 
@@ -37,9 +36,6 @@ const MyReview = ({ type }: Props) => {
               <HandleReview
                 key={review.reviewsId}
                 data={review}
-                nickname={review.nickname}
-                createdAt={review.createdAt}
-                checkLogin={checkLogin}
                 type={type}
                 onClickDel={deleteReview}
               />

--- a/src/component/mypage/Mypage.tsx
+++ b/src/component/mypage/Mypage.tsx
@@ -205,6 +205,7 @@ const Mypage = () => {
             </div>
           ))}
         </div>
+        <div className="tabs-line" />
       </section>
       <div>{selectComponent[currentTab]}</div>
     </>

--- a/src/component/mypage/Mypage.tsx
+++ b/src/component/mypage/Mypage.tsx
@@ -20,7 +20,7 @@ const Mypage = () => {
   const selectComponent: { [key: string]: ReactNode } = {
     myRent: <MyRent />,
     myReservation: <MyReservation />,
-    myReview: <MyReview type="myReviews" />,
+    myReview: <MyReview />,
   };
   const user = window.localStorage.getItem("user");
   const userId = user && JSON.parse(user).id;

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -63,74 +63,57 @@ const HandleReview = ({ type, review, deleteReview }: Props) => {
   return (
     <div className={`showReview__${type}-review-box`}>
       <div className="review-info">
-        {type === "book" ? (
-          <span className="reviewer-name font-12-bold">
-            {review.nickname ?? "미인증 유저"}
-          </span>
-        ) : null}
-        <span className="review-day font-12">{dateFormat(review.createdAt)}</span>
+        <span className={`reviewer-name ${type}`}>
+          {review.nickname ?? "미인증 유저"}
+        </span>
+        <span className="review-day">{dateFormat(review.createdAt)}</span>
       </div>
       <div className="review-content">
-        {type === "book" ? null : (
-          <div className="review-content-book-title font-14-bold">
-            {review.title}
-          </div>
-        )}
+        <div className={`review-content-book-title ${type}`}>
+          {review.title}
+        </div>
+        <textarea
+          className={`review-content-area ${isEditMode ? "edit" : ""}`}
+          value={content}
+          onChange={e => setContent(e.target.value)}
+          disabled={!isEditMode}
+        />
+      </div>
+      <div className={`review-manage ${hasPermissionToEdit ? "" : "hidden"}`}>
         {isEditMode ? (
-          <div>
-            <textarea
-              className="review-content-fix-area font-12"
-              value={content}
-              onChange={e => setContent(e.target.value)}
-            />
+          <div className="review-manage__fix-buttons">
+            <button type="button" onClick={updateChange}>
+              <span className="fix-text">수정하기</span>
+            </button>
+            <button
+              className="review-manage__fix-cancle"
+              type="button"
+              onClick={resetEdited}
+            >
+              취소하기
+            </button>
           </div>
         ) : (
-          <div>
-            <textarea
-              className="review-content-area font-12"
-              value={content}
-              disabled
-            />
+          <div className="review-manage__start-fix-buttons">
+            <button type="button" onClick={startEditMode}>
+              수정
+              <Image
+                className="review-manage__button-img"
+                src={UserEdit}
+                alt=""
+              />
+            </button>
+            <button type="button" onClick={requestConfirmToDelete}>
+              삭제
+              <Image
+                className="review-manage__button-img"
+                src={DeleteButton}
+                alt=""
+              />
+            </button>
           </div>
         )}
       </div>
-      {hasPermissionToEdit ? (
-        <div className="review-manage">
-          {isEditMode ? (
-            <div className="review-manage__fix-buttons font-12">
-              <button type="button" onClick={updateChange}>
-                <span className="fix-text">수정하기</span>
-              </button>
-              <button
-                className="review-manage__fix-cancle"
-                type="button"
-                onClick={resetEdited}
-              >
-                취소하기
-              </button>
-            </div>
-          ) : (
-            <div className="review-manage__start-fix-buttons font-12">
-              <button type="button" onClick={startEditMode}>
-                수정
-                <Image
-                  className="review-manage__button-img"
-                  src={UserEdit}
-                  alt=""
-                />
-              </button>
-              <button type="button" onClick={requestConfirmToDelete}>
-                삭제
-                <Image
-                  className="review-manage__button-img"
-                  src={DeleteButton}
-                  alt=""
-                />
-              </button>
-            </div>
-          )}
-        </div>
-      ) : null}
     </div>
   );
 };

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -5,9 +5,10 @@ import Image from "./Image";
 import UserEdit from "../../asset/img/edit.svg";
 import DeleteButton from "../../asset/img/x_button.svg";
 import "../../asset/css/Review.css";
-import { User } from "@sentry/react";
 import { Review } from "../../type";
 import { useNewDialog } from "../../hook/useNewDialog";
+import userState from "../../atom/userState";
+import { useRecoilValue } from "recoil";
 
 type Props = {
   type: "my" | "book";
@@ -19,7 +20,7 @@ const HandleReview = ({ type, review, deleteReview }: Props) => {
   const [fixReview, setFixReview] = useState(false);
   const [content, setContent] = useState(review.content);
   const uploadDate = splitDate(review.createdAt)[0];
-  const checkLogin = JSON.parse(localStorage.getItem("login") ?? "{}");
+  const checkLogin = useRecoilValue(userState);
   const getPermission = () => {
     if (checkLogin === null) {
       return false;

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -1,13 +1,13 @@
 import { ChangeEventHandler, useState } from "react";
-import axiosPromise from "../../../util/axios";
-import { splitDate } from "../../../util/date";
-import Image from "../../utils/Image";
-import UserEdit from "../../../asset/img/edit.svg";
-import DeleteButton from "../../../asset/img/x_button.svg";
-import "../../../asset/css/Review.css";
+import axiosPromise from "../../util/axios";
+import { splitDate } from "../../util/date";
+import Image from "./Image";
+import UserEdit from "../../asset/img/edit.svg";
+import DeleteButton from "../../asset/img/x_button.svg";
+import "../../asset/css/Review.css";
 import { User } from "@sentry/react";
-import { Review } from "../../../type";
-import { useNewDialog } from "../../../hook/useNewDialog";
+import { Review } from "../../type";
+import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   data: Review;

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -11,30 +11,21 @@ import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   data: Review;
-  nickname: string;
-  createdAt: string;
-  checkLogin: User;
   type: string;
   onClickDel: (id: number) => void;
 };
 
-const HandleReview = ({
-  data,
-  nickname,
-  createdAt,
-  checkLogin,
-  type,
-  onClickDel,
-}: Props) => {
+const HandleReview = ({ data, type, onClickDel }: Props) => {
   const [fixReview, setFixReview] = useState(false);
   const [content, setContent] = useState(data.content);
-  const uploadDate = splitDate(createdAt)[0];
+  const uploadDate = splitDate(data.createdAt)[0];
+  const checkLogin = JSON.parse(localStorage.getItem("login") ?? "{}");
   const getPermission = () => {
     if (checkLogin === null) {
       return false;
     }
     const user = checkLogin.userName;
-    const checkReviewerNickname = user === nickname;
+    const checkReviewerNickname = user === data.nickname;
     return checkReviewerNickname;
   };
   const permission = getPermission();
@@ -95,7 +86,7 @@ const HandleReview = ({
       <div className="review-info">
         {type === "bookReviews" ? (
           <span className="reviewer-name font-12-bold">
-            {nickname ?? "미인증 유저"}
+            {data.nickname ?? "미인증 유저"}
           </span>
         ) : null}
         <span className="review-day font-12">{uploadDate}</span>
@@ -166,14 +157,3 @@ const HandleReview = ({
 };
 
 export default HandleReview;
-
-HandleReview.defaultProps = {
-  data: {
-    bookInfoId: null,
-    content: null,
-    reviewsId: null,
-    title: null,
-  },
-  nickname: null,
-  checkLogin: null,
-};

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -10,22 +10,22 @@ import { Review } from "../../type";
 import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
-  data: Review;
-  type: string;
-  onClickDel: (id: number) => void;
+  type: "my" | "book";
+  review: Review;
+  deleteReview: (id: number) => void;
 };
 
-const HandleReview = ({ data, type, onClickDel }: Props) => {
+const HandleReview = ({ type, review, deleteReview }: Props) => {
   const [fixReview, setFixReview] = useState(false);
-  const [content, setContent] = useState(data.content);
-  const uploadDate = splitDate(data.createdAt)[0];
+  const [content, setContent] = useState(review.content);
+  const uploadDate = splitDate(review.createdAt)[0];
   const checkLogin = JSON.parse(localStorage.getItem("login") ?? "{}");
   const getPermission = () => {
     if (checkLogin === null) {
       return false;
     }
     const user = checkLogin.userName;
-    const checkReviewerNickname = user === data.nickname;
+    const checkReviewerNickname = user === review.nickname;
     return checkReviewerNickname;
   };
   const permission = getPermission();
@@ -34,12 +34,8 @@ const HandleReview = ({ data, type, onClickDel }: Props) => {
   };
 
   const cancelFixBtn = () => {
-    setContent(data.content);
+    setContent(review.content);
     return setFixReview(!fixReview);
-  };
-
-  const deleteReview = () => {
-    onClickDel(data.reviewsId);
   };
 
   const { addConfirmDialog, addDialogWithTitleAndMessage } = useNewDialog();
@@ -47,8 +43,8 @@ const HandleReview = ({ data, type, onClickDel }: Props) => {
     addConfirmDialog(
       "삭제확인",
       "리뷰를 삭제하시겠습니까?",
-      data.content,
-      deleteReview,
+      review.content,
+      () => deleteReview(review.reviewsId),
     );
   };
 
@@ -56,7 +52,7 @@ const HandleReview = ({ data, type, onClickDel }: Props) => {
     const text = {
       content,
     };
-    axiosPromise("put", `/reviews/${data.reviewsId}`, text)
+    axiosPromise("put", `/reviews/${review.reviewsId}`, text)
       .then(() => {
         setFixReview(!fixReview);
       })
@@ -78,23 +74,19 @@ const HandleReview = ({ data, type, onClickDel }: Props) => {
   };
 
   return (
-    <div
-      className={`showReview__${
-        type === "bookReviews" ? "book" : "my"
-      }-review-box`}
-    >
+    <div className={`showReview__${type}-review-box`}>
       <div className="review-info">
-        {type === "bookReviews" ? (
+        {type === "book" ? (
           <span className="reviewer-name font-12-bold">
-            {data.nickname ?? "미인증 유저"}
+            {review.nickname ?? "미인증 유저"}
           </span>
         ) : null}
         <span className="review-day font-12">{uploadDate}</span>
       </div>
       <div className="review-content">
-        {type === "bookReviews" ? null : (
+        {type === "book" ? null : (
           <div className="review-content-book-title font-14-bold">
-            {data.title}
+            {review.title}
           </div>
         )}
         {fixReview ? (

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { splitDate } from "../../util/date";
+import { dateFormat } from "../../util/date";
 import Image from "./Image";
 import UserEdit from "../../asset/img/edit.svg";
 import DeleteButton from "../../asset/img/x_button.svg";
@@ -18,15 +18,13 @@ type Props = {
 
 const HandleReview = ({ type, review, deleteReview }: Props) => {
   const [isEditMode, setEditMode] = useState(false);
-  const uploadDate = splitDate(review.createdAt)[0];
-
   const user = useRecoilValue(userState);
   const hasPermissionToEdit = user && user.userName === review.nickname;
 
   const startEditMode = () => setEditMode(true);
   const finishEditMode = () => setEditMode(false);
   const initialContent = review.content;
-  
+
   const { content, setContent, request } = usePutReviewsReviewsId({
     reviewsId: review.reviewsId,
     initialContent,
@@ -70,7 +68,7 @@ const HandleReview = ({ type, review, deleteReview }: Props) => {
             {review.nickname ?? "미인증 유저"}
           </span>
         ) : null}
-        <span className="review-day font-12">{uploadDate}</span>
+        <span className="review-day font-12">{dateFormat(review.createdAt)}</span>
       </div>
       <div className="review-content">
         {type === "book" ? null : (

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -9,6 +9,7 @@ import { useNewDialog } from "../../hook/useNewDialog";
 import userState from "../../atom/userState";
 import { useRecoilValue } from "recoil";
 import { usePutReviewsReviewsId } from "../../api/reviews/usePutReviewsReviewsId";
+import { Link } from "react-router-dom";
 
 type Props = {
   type: "my" | "book";
@@ -69,9 +70,12 @@ const HandleReview = ({ type, review, deleteReview }: Props) => {
         <span className="review-day">{dateFormat(review.createdAt)}</span>
       </div>
       <div className="review-content">
-        <div className={`review-content-book-title ${type}`}>
+        <Link
+          to={`/info/${review.bookInfoId}`}
+          className={`review-content-book-title ${type}`}
+        >
           {review.title}
-        </div>
+        </Link>
         <textarea
           className={`review-content-area ${isEditMode ? "edit" : ""}`}
           value={content}


### PR DESCRIPTION
# 개요
- 42library와 현재 develop 간 UI 오류를 해결했습니다
- 기타 코드 가독성 개선을 위한 리팩토링을 진행했습니다. 
- fixes #495

### 해결한 UI 오류
- [x] 마이페이지 날짜 대신 연도
- [x] 수정 삭제 안보임
- [x] post 성공했으나 성공알림 없음
- [x] 상세페이지 get 요청 실패

### 추가 변경사항
- api 호출부 분리
- 마이페이지 탭 아래 선 추가
- 마이페이지 책 제목 클릭시 해당 상세페이지로 이동
- 기타 변수명 변경

### privew
|페이지|캡처이미지|
|---|---|
|마이페이지 UI 일치|<img width="1553" alt="image" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/7fd775a6-26d2-4c0a-a4b6-a12e15fe9e8f">|
|상세페이지 UI 일치|<img width="1556" alt="image" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/99d25c2b-2fc2-4c61-a9c7-6fa3f42575e1">|
|리뷰 등록시 알림|![Jul-19-2023 02-00-08](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/80d7ffed-7569-415b-8d05-2639a5cc0f25)|


###
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
