### PR TITLE
fix: 대출 QR 인식 성공때는 closeModal 실행안되도록 수정

### DIFF
--- a/src/component/rent/RentModalBook.tsx
+++ b/src/component/rent/RentModalBook.tsx
@@ -39,7 +39,9 @@ const RentModalBook = ({
         "다시 한번 확인해주세요",
       );
       closeModal();
-    } else setBookId(bookId);
+    } else { 
+      setBookId(bookId);
+    }
   };
 
   const { bookList, lastPage, page, setPage, setQuery } = useGetBooksSearch({

--- a/src/component/rent/RentModalBook.tsx
+++ b/src/component/rent/RentModalBook.tsx
@@ -32,14 +32,14 @@ const RentModalBook = ({
     const isAlreadySelected = selectedBooks.some(
       book => book.bookId === +bookId,
     );
-    if (isAlreadySelected)
+    if (isAlreadySelected) {
       addDialogWithTitleAndMessage(
         "alreadySelected",
         "이미 선택된 도서입니다.",
         "다시 한번 확인해주세요",
       );
-    else setBookId(bookId);
-    closeModal();
+      closeModal();
+    } else setBookId(bookId);
   };
 
   const { bookList, lastPage, page, setPage, setQuery } = useGetBooksSearch({


### PR DESCRIPTION
# 개요
- fixes #496

대출 인식 성공 후 바로 close하면
id로 책정보가져오는 요청이 진행되지 않음
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
