### PR TITLE
fix:상세페이지 네트워크 실패시 UI 개선

### DIFF
--- a/src/asset/css/BookDetail.css
+++ b/src/asset/css/BookDetail.css
@@ -4,6 +4,7 @@
   margin: auto;
   margin-top: 7rem;
   margin-bottom: 10rem;
+  min-height: 20rem;
 }
 
 .book-detail__reservation-button {
@@ -156,11 +157,11 @@
   }
 
   .book-detail__info-status {
-	font-size: 1.6rem;
+    font-size: 1.6rem;
   }
 
   .book-content {
-	justify-content: space-evenly;
+    justify-content: space-evenly;
   }
 }
 

--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -17,7 +17,19 @@ const BookDetail = () => {
   useEffect(() => myRef.current?.scrollIntoView(), []);
   const { bookDetailInfo } = useGetBooksInfoId({ id });
 
-  if (!bookDetailInfo) return null;
+  if (!bookDetailInfo) {
+    return (
+      <main>
+        <Banner
+          img="bookdetail"
+          titleKo="도서 상세 및 예약"
+          titleEn="DETAIL & RESERVATION"
+        />
+        <section className="book-detail-body" />
+      </main>
+    );
+  }
+
   const isAvailableReservation = () => {
     const { books } = bookDetailInfo;
     const noProblemBooksCnt = books?.filter(book => book.status === 0).length;


### PR DESCRIPTION
# 개요
책정보를 불러올 수 없는 상황에도 기본 UI 유지하도록 수정

- fixes #509

### preview
| |이미지|
|---|---|
|before|![image](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/731a4efb-a8ce-479d-b541-6a18f1eef0e2)|
|after|<img width="1615" alt="image" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/800040dd-c758-4005-99d5-f22b41513a99">|


<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
