### PR TITLE
fix: 메인페이지 인기 도서 순위 오류 해결

### DIFF
--- a/src/api/books/useGetBooksInfoNew.ts
+++ b/src/api/books/useGetBooksInfoNew.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
 import { compareExpect } from "../../util/typeCheck";
-import { Book } from "../../type";
+import { BookInfo } from "../../type";
 
 export const useGetBooksInfoNew = () => {
-  const [bookList, setBookList] = useState<Book[]>([]);
+  const [bookList, setBookList] = useState<BookInfo[]>([]);
 
   const { request } = useApi("get", "books/info/", {
     sort: "new",

--- a/src/api/books/useGetBooksInfoPopular.ts
+++ b/src/api/books/useGetBooksInfoPopular.ts
@@ -4,7 +4,7 @@ import { compareExpect } from "../../util/typeCheck";
 import { BookInfo } from "../../type";
 
 export const useGetBooksInfoPopular = () => {
-  const [docs, setDocs] = useState<BookInfo[]>([]);
+  const [docs, setDocs] = useState<(BookInfo & { rank: number })[]>([]);
 
   const { request } = useApi("get", "books/info", {
     sort: "popular",
@@ -27,7 +27,11 @@ export const useGetBooksInfoPopular = () => {
       response.data.items,
       expectedItem,
     );
-    setDocs(books);
+    const booksWithRank = books.map((book, index) => ({
+      ...book,
+      rank: index + 1,
+    }));
+    setDocs(booksWithRank);
   };
 
   useEffect(() => request(refineResponse), []);

--- a/src/api/books/useGetBooksInfoPopular.ts
+++ b/src/api/books/useGetBooksInfoPopular.ts
@@ -1,10 +1,10 @@
 import { useState, useEffect } from "react";
 import { useApi } from "../../hook/useApi";
 import { compareExpect } from "../../util/typeCheck";
-import { Book } from "../../type";
+import { BookInfo } from "../../type";
 
 export const useGetBooksInfoPopular = () => {
-  const [docs, setDocs] = useState<Book[]>([]);
+  const [docs, setDocs] = useState<BookInfo[]>([]);
 
   const { request } = useApi("get", "books/info", {
     sort: "popular",

--- a/src/component/main/MainNewBook.tsx
+++ b/src/component/main/MainNewBook.tsx
@@ -1,12 +1,9 @@
 import { Link } from "react-router-dom";
 import Image from "../utils/Image";
+import { BookInfo } from "../../type";
 
 type Props = {
-  book: {
-    id?: number;
-    image?: string;
-    title?: string;
-  };
+  book: BookInfo;
   bookWidth: number;
 };
 

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -4,12 +4,13 @@ import MainNewBookPagination from "./MainNewBookPagination";
 import Image from "../utils/Image";
 import ArrLeft from "../../asset/img/arrow_left.svg";
 import ArrRight from "../../asset/img/arrow_right.svg";
+import { BookInfo } from "../../type";
 
 const mobileWidth = 100;
 const pcWidth = 200;
 
 type Props = {
-  docs: object[];
+  docs: BookInfo[];
 };
 
 const MainNewBookList = ({ docs }: Props) => {

--- a/src/component/main/MainPopularCenter.tsx
+++ b/src/component/main/MainPopularCenter.tsx
@@ -1,10 +1,10 @@
 import { MouseEventHandler, TouchEventHandler, useState } from "react";
 import Image from "../utils/Image";
-import { Book } from "../../type";
+import { BookInfo } from "../../type";
 import { useNavigate } from "react-router-dom";
 
 type Props = {
-  docs: Book[];
+  docs: BookInfo[];
   centerTop: number;
   onLeft: () => void;
   onRight: () => void;
@@ -100,7 +100,7 @@ const MainPopularCenter = ({ docs, centerTop, onLeft, onRight }: Props) => {
                 />
                 <div className="main__popular__summary">
                   <span className="main__popular__rank font-48-bold">
-                    {index + 1}
+                    {book.rank}
                   </span>
                   <p className="font-16-light color-2d"> #{book.category}</p>
                   <p className="font-32-bold color-2d">{book.title}</p>

--- a/src/component/main/MainPopularCenter.tsx
+++ b/src/component/main/MainPopularCenter.tsx
@@ -4,7 +4,7 @@ import { BookInfo } from "../../type";
 import { useNavigate } from "react-router-dom";
 
 type Props = {
-  docs: BookInfo[];
+  docs: (BookInfo & { rank: number })[];
   centerTop: number;
   onLeft: () => void;
   onRight: () => void;

--- a/src/component/main/MainPopularSide.tsx
+++ b/src/component/main/MainPopularSide.tsx
@@ -1,9 +1,9 @@
 import { MouseEventHandler } from "react";
-import { Book } from "../../type";
+import { BookInfo } from "../../type";
 import Image from "../utils/Image";
 
 type Props = {
-  books: Book[];
+  books: BookInfo[];
   onClick: MouseEventHandler;
   side: "left" | "right";
 };


### PR DESCRIPTION
# 개요
- fixes #519

### 변경사항
- 메인 인기도서 및 메인페이지의 책타입 변경 
  - 책정보에 해당하기 때문에 BookInfo가 더 적절
 - 인기도서 rank 속성 추가 `(BookInfo & { rank: number })[];`

### 문제 원인 및 해결
- book.rank 타입오류, rank는 없는 속성 
- 네트워크 반환받은 값에 rank 값 추가 index + 1

### preview
|before|after|
|---|---|
|![https://user-images.githubusercontent.com/85754295/254524735-5aa499d1-b7f8-4184-9479-a806731c2abd.png](https://user-images.githubusercontent.com/85754295/254524735-5aa499d1-b7f8-4184-9479-a806731c2abd.png)|<img width="1120" alt="image" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/6f79e2b2-6b5e-4678-9a47-cdc0fee12ae4">|
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
