### PR TITLE
fix: 도서 수정 categoryId를 숫자로 변경

### DIFF
--- a/src/component/bookManagement/BookManagementModalDetail.tsx
+++ b/src/component/bookManagement/BookManagementModalDetail.tsx
@@ -57,7 +57,7 @@ const BookManagementModalDetail = ({ book, closeModal }: Props) => {
     modifyFromRef("callSign", callSignRef);
     modifyFromRef("categoryId", categoryRef);
     modifyFromRef("status", statusRef);
-    change.categoryId += 1; // select option의 index는 0부터 시작하므로 +1
+    change.categoryId = Number(change.categoryId) + 1; // select option의 index는 0부터 시작하므로 +1
     return change;
   };
 
@@ -166,7 +166,7 @@ const BookManagementModalDetail = ({ book, closeModal }: Props) => {
             ref={categoryRef}
             resetDependency={reset}
             optionList={category.map(i => i.name)}
-            initialSelectedIndex={book.categoryId - 1}
+            initialSelectedIndex={Number(book.categoryId) - 1}
           />
         </div>
       </div>


### PR DESCRIPTION
# 개요

![image](https://github.com/jiphyeonjeon-42/frontend/assets/54838975/b25a8d8d-9cc7-417d-89b3-1716a3bb1e86)

도서 수정 페이지에서 수정 요청을 보낼시 categoryId가 문자열로 보내져 연산에 오류가 생기는 문제가 있었습니다.