### PR TITLE
fix: Image 컴포넌트 에러 처리 방식 변경

### DIFF
--- a/src/component/utils/Image.tsx
+++ b/src/component/utils/Image.tsx
@@ -5,14 +5,13 @@ type Size = number;
 type Props = HTMLProps<HTMLImageElement> & { width?: Size; height?: Size };
 
 const Image = ({ src, alt, width, height, ...props }: Props) => {
-  const [error, setError] = useState(false);
   return (
     <img
       {...props}
-      src={error ? fallback : src}
+      src={src}
       alt={alt}
       style={{ width, height }}
-      onError={() => setError(true)}
+      onError={e => (e.currentTarget.src = fallback)}
       loading="lazy"
     />
   );


### PR DESCRIPTION
### 변경사항
- error state 삭제
- 에러가 발생하면 img 엘리먼트의 src값이 바뀌도록 수정

- fixes #441 

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
