### PR TITLE
build: 절대경로 import 추가, `MyRentInfo`에 절대경로 적용

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "react-router-dom": "^6.11.2",
     "recoil": "^0.7.7",
     "vite": "^4.3.8",
+    "vite-tsconfig-paths": "^4.2.0",
     "web-vitals": "^3.3.1"
   },
   "scripts": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: '6.1'
+lockfileVersion: '6.0'
 
 settings:
   autoInstallPeers: true
@@ -65,6 +65,9 @@ dependencies:
   vite:
     specifier: ^4.3.8
     version: 4.3.8
+  vite-tsconfig-paths:
+    specifier: ^4.2.0
+    version: 4.2.0(vite@4.3.8)
   web-vitals:
     specifier: ^3.3.1
     version: 3.3.1
@@ -4703,6 +4706,17 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: false
 
+  /tsconfck@2.1.2:
+    resolution: {integrity: sha512-ghqN1b0puy3MhhviwO2kGF8SeMDNhEbnKxjK7h6+fvY9JAxqvXi8y5NAHSQv687OVboS2uZIByzGd45/YxrRHg==}
+    engines: {node: ^14.13.1 || ^16 || >=18}
+    hasBin: true
+    peerDependencies:
+      typescript: ^4.3.5 || ^5.0.0
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dev: false
+
   /tsconfig-paths@3.14.2:
     resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
     dependencies:
@@ -4904,6 +4918,23 @@ packages:
       vite: 4.2.1
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /vite-tsconfig-paths@4.2.0(vite@4.3.8):
+    resolution: {integrity: sha512-jGpus0eUy5qbbMVGiTxCL1iB9ZGN6Bd37VGLJU39kTDD6ZfULTTb1bcc5IeTWqWJKiWV5YihCaibeASPiGi8kw==}
+    peerDependencies:
+      vite: '*'
+    peerDependenciesMeta:
+      vite:
+        optional: true
+    dependencies:
+      debug: 4.3.4
+      globrex: 0.1.2
+      tsconfck: 2.1.2
+      vite: 4.3.8
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
     dev: false
 
   /vite@4.2.1:

--- a/src/api/like/index.ts
+++ b/src/api/like/index.ts
@@ -1,0 +1,3 @@
+export * from "./useDeleteLike";
+export * from "./useGetLike";
+export * from "./usePostLike";

--- a/src/component/mypage/MyRentInfo/MyRent.tsx
+++ b/src/component/mypage/MyRentInfo/MyRent.tsx
@@ -1,8 +1,8 @@
-import { useGetUsersSearchId } from "../../../api/users/useGetUsersSearchId";
+import { useGetUsersSearchId } from "~/api/users/useGetUsersSearchId";
 import RentHistory from "./RentHistory";
 import RentedOrReservedBooks from "./RentedOrReservedBooks";
-import InquireBoxTitle from "../../utils/InquireBoxTitle";
-import Book from "../../../asset/img/admin_icon.svg";
+import InquireBoxTitle from "~/component/utils/InquireBoxTitle";
+import Book from "~/asset/img/admin_icon.svg";
 
 const MyRent = () => {
   const user = window.localStorage.getItem("user");

--- a/src/component/mypage/MyRentInfo/RentHistory.tsx
+++ b/src/component/mypage/MyRentInfo/RentHistory.tsx
@@ -1,7 +1,7 @@
-import Pagination from "../../utils/Pagination";
-import { useGetHistories } from "../../../api/histories/useGetHistories";
+import Pagination from "~/component/utils/Pagination";
+import { useGetHistories } from "~/api/histories/useGetHistories";
 import RentHistoryTable from "./RentHistoryTable";
-import "../../../asset/css/RentHistory.css";
+import "~/asset/css/RentHistory.css";
 
 const RentHistory = () => {
   const { historiesList, lastPage, page, setPage } = useGetHistories({

--- a/src/component/mypage/MyRentInfo/RentHistoryTable.tsx
+++ b/src/component/mypage/MyRentInfo/RentHistoryTable.tsx
@@ -1,12 +1,10 @@
 import { useState } from "react";
-import { useGetLike } from "../../../api/like/useGetLike";
-import { usePostLike } from "../../../api/like/usePostLike";
-import { useDeleteLike } from "../../../api/like/useDeleteLike";
-import Image from "../../utils/Image";
-import FilledLike from "../../../asset/img/like_filled.svg";
-import EmptyLike from "../../../asset/img/like_empty.svg";
-import { History } from "../../../type";
-import "../../../asset/css/RentHistory.css";
+import { useGetLike, usePostLike, useDeleteLike } from "~/api/like";
+import Image from "~/component/utils/Image";
+import FilledLike from "~/asset/img/like_filled.svg";
+import EmptyLike from "~/asset/img/like_empty.svg";
+import type { History } from "~/type";
+import "~/asset/css/RentHistory.css";
 
 type Props = {
   factor: History;

--- a/src/component/mypage/MyRentInfo/RentedOrReservedBooks.tsx
+++ b/src/component/mypage/MyRentInfo/RentedOrReservedBooks.tsx
@@ -1,8 +1,8 @@
-import { usePatchReservationsCancel } from "../../../api/reservations/usePatchReservationsCancel";
-import Image from "../../utils/Image";
-import { isNumber } from "../../../util/typeCheck";
-import { Lending, Reservation } from "../../../type";
-import "../../../asset/css/RentedOrReservedBooks.css";
+import { usePatchReservationsCancel } from "~/api/reservations/usePatchReservationsCancel";
+import Image from "~/component/utils/Image";
+import { isNumber } from "~/util/typeCheck";
+import { Lending, Reservation } from "~/type";
+import "~/asset/css/RentedOrReservedBooks.css";
 
 type Props = {
   componentMode: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "paths": { "~/*": ["./src/*"] }
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.vite.json" }]

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,7 @@
 import { defineConfig, loadEnv } from "vite";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import react from "@vitejs/plugin-react-swc";
+import tsconfigPaths from "vite-tsconfig-paths";
 
 /**
  * REACT_APP_ 으로 시작하는 환경변수를
@@ -21,7 +22,7 @@ export default defineConfig(({ mode }) => {
 
   return {
     /** @see https://vitejs.dev/plugins/ */
-    plugins: [react()],
+    plugins: [react(), tsconfigPaths()],
 
     envPrefix,
 


### PR DESCRIPTION
# 개요

![image](https://github.com/jiphyeonjeon-42/frontend/assets/54838975/854fb0a2-8203-430f-956e-d3e3cfe1316e)

- fixes #541

## 내용

1. 절대경로 `~`를 사용해 import를 할 수 있도록 `tsconfig.json`에 `paths` 매핑을 추가했습니다.
2. vite가 개발 모드와 빌드 시 `paths`를 이해할 수 있게 `vite-tsconfig-paths` 플러그인을 추가했습니다.
3. 사용 예시를 들기 위해 `src/component/mypage/MyRentInfo`의 import를 절대 경로로 변경했습니다.