### PR TITLE
feat: 도서 상태 정보를 청구기호 순으로 정렬

### DIFF
--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -9,6 +9,20 @@ import Image from "~/component/utils/Image";
 import Like from "~/component/book/like/Like";
 import TagWrapper from "~/component/book/tag/TagWrapper";
 import "~/asset/css/BookDetail.css";
+import { Book } from "~/type";
+
+const callsignToNumbers = (callSign: string) =>
+  callSign
+    .replace(/[^0-9\.]/g, "")
+    .split(".")
+    .map(Number);
+
+const compareCallsign = (a: Book, b: Book) => {
+  const xs = callsignToNumbers(a.callSign);
+  const ys = callsignToNumbers(b.callSign);
+
+  return xs.reduce((sum, x, i) => sum + (x - ys[i]), 0);
+};
 
 const BookDetail = () => {
   const id = useParams().id || "";
@@ -104,9 +118,15 @@ const BookDetail = () => {
               </span>
               <div className="book-state__list">
                 <div>
-                  {bookDetailInfo.books?.map((book, index) => (
-                    <BookStatus key={book.id} book={book} index={index} />
-                  ))}
+                  {bookDetailInfo.books
+                    ?.toSorted((a, b) => compareCallsign(a, b))
+                    .map((book, index) => (
+                      <BookStatus
+                        key={book.callSign}
+                        book={book}
+                        index={index}
+                      />
+                    ))}
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# 개요

- fixes #531 

![image](https://github.com/jiphyeonjeon-42/frontend/assets/54838975/e4343437-30e7-4695-9f04-dc718b734189)

## 기타

https://github.com/jiphyeonjeon-42/backend/blob/bfbb03c68601f812bf43763e9c0544c9907853fc/backend/src/v1/books/books.service.ts#L397

처음부터 백엔드에서 돌려줄 때 청구기호 순으로 정렬해 돌려주는 것도 좋을 것 같습니다.