### PR TITLE
refactor: 검색창 컴포넌트 개선 및 드롭다운 UI 추가

### DIFF
--- a/src/asset/css/SearchBar.css
+++ b/src/asset/css/SearchBar.css
@@ -4,6 +4,7 @@
   display: flex;
   border-radius: 6.1rem;
   background-color: #f2f2f2;
+  position: relative;
 }
 
 .search-bar__wrapper.short {

--- a/src/asset/css/SearchBarDropDown.css
+++ b/src/asset/css/SearchBarDropDown.css
@@ -1,6 +1,6 @@
 .search-bar__dropdown {
   text-align: left;
-  background-color: white !important;
+  background-color: rgba(255, 255, 255, 0.6) !important;
   position: absolute;
   top: 6.4rem;
   padding: 1rem;

--- a/src/asset/css/SearchBarDropDown.css
+++ b/src/asset/css/SearchBarDropDown.css
@@ -1,0 +1,22 @@
+.search-bar__dropdown {
+  text-align: left;
+  background-color: white !important;
+  position: absolute;
+  top: 6.4rem;
+  padding: 1rem;
+  white-space: wrap;
+  width: calc(100% - 5.4rem);
+  box-sizing: border-box;
+}
+
+@media screen and (max-width: 1200px) {
+  .search-bar__dropdown {
+    top: 5.5rem;
+  }
+}
+
+@media screen and (max-width: 767px) {
+  .search-bar__dropdown {
+    top: 5rem;
+  }
+}

--- a/src/asset/css/SearchBarDropDown.css
+++ b/src/asset/css/SearchBarDropDown.css
@@ -3,7 +3,6 @@
   background-color: rgba(255, 255, 255, 0.6) !important;
   position: absolute;
   top: 6.4rem;
-  padding: 1rem;
   white-space: wrap;
   width: calc(100% - 5.4rem);
   box-sizing: border-box;

--- a/src/component/main/MainBanner.tsx
+++ b/src/component/main/MainBanner.tsx
@@ -1,4 +1,4 @@
-import SearchBar from "../utils/SearchBar";
+import BookSearchBar from "../utils/BookSearchBar";
 import "../../asset/css/Banner.css";
 import "../../asset/css/MainBanner.css";
 
@@ -18,7 +18,7 @@ const MainBanner = () => {
           <span className="main-banner__guide2 font-16 color-d5">
             검색창에 원하는 도서를 입력해주세요.
           </span>
-          <SearchBar width="banner" isNavigate />
+          <BookSearchBar />
         </div>
         <div className="main-banner__scroll">
           <p className="font-12 color-d5">스크롤을 내려주세요</p>

--- a/src/component/search/SearchBanner.tsx
+++ b/src/component/search/SearchBanner.tsx
@@ -1,4 +1,4 @@
-import SearchBar from "../utils/SearchBar";
+import BookSearchBar from "../utils/BookSearchBar";
 import "../../asset/css/Banner.css";
 import "../../asset/css/SearchBanner.css";
 
@@ -18,11 +18,7 @@ const SearchBanner = ({ setQuery }: Props) => {
             SEARCH
           </span>
         </div>
-        <SearchBar
-          setQuery={setQuery}
-          width="banner"
-          isFocusedOnMount={false}
-        />
+        <BookSearchBar />
       </section>
     </section>
   );

--- a/src/component/superTag/SuperTagMergeDefaultTag.tsx
+++ b/src/component/superTag/SuperTagMergeDefaultTag.tsx
@@ -2,7 +2,7 @@ import { DragEventHandler, useState } from "react";
 import { usePatchTagsBookInfoIdMerge } from "../../api/tags/usePatchTagsBookInfoIdMerge";
 import { Tag } from "../../type";
 import Accordion from "../utils/Accordion";
-import SearchBar from "../utils/SearchBar";
+import ManagementSearchBar from "../utils/ManagementSearchBar";
 import Droppable from "../utils/Droppable";
 import SuperTagMergeSubTag from "./SuperTagMergeSubTag";
 
@@ -49,7 +49,7 @@ const SuperTagMergeDefaultTag = ({
             format="text/plain"
             onDrop={addNewListAndMergeIfMoved}
           >
-            <SearchBar
+            <ManagementSearchBar
               wrapperClassName="super-tag__default__search-bar"
               width="short"
               placeHolder="분류없음 내 검색"

--- a/src/component/userManagement/UserManagement.tsx
+++ b/src/component/userManagement/UserManagement.tsx
@@ -3,7 +3,7 @@ import Banner from "../utils/Banner";
 import Tabs from "../utils/Tabs";
 import UserBriefInfo from "./UserBriefInfo";
 import UserUsageInfo from "./UserUsageInfo";
-import SearchBar from "../utils/SearchBar";
+import ManagementSearchBar from "../utils/ManagementSearchBar";
 import Pagination from "../utils/Pagination";
 import Modal from "../utils/Modal";
 import ModalHeader from "../utils/ModalHeader";
@@ -32,7 +32,7 @@ const UserManagement = () => {
       <Tabs tabList={userManagementTabList} />
       <section className="user-management-body">
         <div className="user-management-search">
-          <SearchBar
+          <ManagementSearchBar
             width="center"
             placeHolder="nickname 또는 email을 입력해주세요."
             setQuery={setQuery}

--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -1,10 +1,14 @@
-import { FormEventHandler, useEffect, useState } from "react";
+import { FormEventHandler, useEffect, useRef, useState } from "react";
 import { useNavigate, useSearchParams } from "react-router-dom";
-import SearchBar from "./SearchBar";
+import SearchBar from "~/component/utils/SearchBar";
+import BookSearchPreview from "~/component/utils/BookSearchPreview";
+import BookSearchRecentKeyword from "~/component/utils/BookSearchRecentKeywords";
 
 const BookSearchBar = () => {
+  const [isOpened, setIsOpened] = useState(false);
   const [keyword, setKeyword] = useState("");
   const [params] = useSearchParams();
+  const ref = useRef<HTMLInputElement>(null);
   const navigate = useNavigate();
 
   const goToSearchPage: FormEventHandler<HTMLFormElement> = e => {
@@ -23,8 +27,20 @@ const BookSearchBar = () => {
       <SearchBar.Input
         value={keyword}
         onChange={e => setKeyword(e.target.value)}
-        ref={undefined}
+        onFocus={() => setIsOpened(true)}
+        ref={ref}
       />
+      <SearchBar.DropDown
+        isOpened={isOpened}
+        setIsOpened={setIsOpened}
+        searchBarRef={ref}
+      >
+        {keyword.length == 0 ? (
+          <BookSearchRecentKeyword />
+        ) : (
+          <BookSearchPreview />
+        )}
+      </SearchBar.DropDown>
       <SearchBar.Button />
     </SearchBar>
   );

--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -15,6 +15,7 @@ const BookSearchBar = () => {
     e.preventDefault();
     const searchWord = e.currentTarget.input.value;
     navigate(`/search?search=${encodeURIComponent(searchWord)}`);
+    e.currentTarget.input.blur();
   };
 
   useEffect(() => {

--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -1,0 +1,33 @@
+import { FormEventHandler, useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import SearchBar from "./SearchBar";
+
+const BookSearchBar = () => {
+  const [keyword, setKeyword] = useState("");
+  const [params] = useSearchParams();
+  const navigate = useNavigate();
+
+  const goToSearchPage: FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+    const searchWord = e.currentTarget.input.value;
+    navigate(`/search?search=${encodeURIComponent(searchWord)}`);
+  };
+
+  useEffect(() => {
+    const currentKeyword = params.get("search");
+    setKeyword(currentKeyword || "");
+  }, [params]);
+
+  return (
+    <SearchBar onSubmit={goToSearchPage}>
+      <SearchBar.Input
+        value={keyword}
+        onChange={e => setKeyword(e.target.value)}
+        ref={undefined}
+      />
+      <SearchBar.Button />
+    </SearchBar>
+  );
+};
+
+export default BookSearchBar;

--- a/src/component/utils/BookSearchPreview.tsx
+++ b/src/component/utils/BookSearchPreview.tsx
@@ -1,0 +1,5 @@
+const BookSearchPreview = () => {
+  return <div>결과 미리보기</div>;
+};
+
+export default BookSearchPreview;

--- a/src/component/utils/BookSearchRecentKeywords.tsx
+++ b/src/component/utils/BookSearchRecentKeywords.tsx
@@ -1,0 +1,5 @@
+const BookSearchRecentKeyword = () => {
+  return <div>최근 검색어</div>;
+};
+
+export default BookSearchRecentKeyword;

--- a/src/component/utils/InquireBoxTitle.tsx
+++ b/src/component/utils/InquireBoxTitle.tsx
@@ -1,5 +1,5 @@
 import Image from "./Image";
-import SearchBar from "./SearchBar";
+import ManagementSearchBar from "./ManagementSearchBar";
 import "../../asset/css/InquireBoxTitle.css";
 
 type Props = {
@@ -51,7 +51,7 @@ const InquireBoxTitle = ({
         </span>
       </span>
       {placeHolder ? (
-        <SearchBar
+        <ManagementSearchBar
           placeHolder={placeHolder}
           width="short"
           setQuery={setQuery}

--- a/src/component/utils/Management.tsx
+++ b/src/component/utils/Management.tsx
@@ -1,4 +1,4 @@
-import SearchBar from "./SearchBar";
+import ManagementSearchBar from "./ManagementSearchBar";
 import Pagination from "./Pagination";
 import "../../asset/css/Management.css";
 
@@ -23,7 +23,7 @@ const Management = ({
 }: Props) => {
   return (
     <section className="management__wrapper">
-      <SearchBar
+      <ManagementSearchBar
         placeHolder={searchBarPlaceHolder}
         width="center"
         wrapperClassName="management__search-bar"

--- a/src/component/utils/ManagementSearchBar.tsx
+++ b/src/component/utils/ManagementSearchBar.tsx
@@ -1,0 +1,68 @@
+import {
+  ChangeEventHandler,
+  MouseEventHandler,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import SearchBar from "~/component/utils/SearchBar";
+
+type Props = {
+  width: "banner" | "center" | "short" | "long";
+  setQuery?: (query: string) => void;
+  placeHolder?: string;
+  wrapperClassName?: string;
+  isWithBarcodeButton?: boolean;
+  isFocusedOnMount?: boolean;
+  onClickBarcodeButton?: MouseEventHandler<HTMLButtonElement>;
+};
+
+const ManagementSearchBar = ({
+  width,
+  setQuery = () => {},
+  placeHolder,
+  wrapperClassName = "",
+  isWithBarcodeButton = false,
+  isFocusedOnMount = true,
+  onClickBarcodeButton = () => {},
+  ...rest
+}: Props) => {
+  const [keyword, setKeyword] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (isFocusedOnMount && searchRef.current) {
+      searchRef.current.focus();
+    }
+  }, []);
+
+  const changeKeyword: ChangeEventHandler<HTMLInputElement> = e => {
+    const changed = e.currentTarget.value;
+    setKeyword(changed);
+    setQuery(changed);
+  };
+
+  return (
+    <SearchBar className={wrapperClassName} width={width}>
+      <SearchBar.Input
+        {...rest}
+        placeholder={placeHolder}
+        value={keyword}
+        onChange={changeKeyword}
+        ref={searchRef}
+      />
+      {isWithBarcodeButton ? (
+        <button
+          type="button"
+          className="search-bar__button barcode"
+          onClick={onClickBarcodeButton}
+        >
+          바코드
+        </button>
+      ) : null}
+      <SearchBar.Button />
+    </SearchBar>
+  );
+};
+
+export default ManagementSearchBar;

--- a/src/component/utils/SearchBar.tsx
+++ b/src/component/utils/SearchBar.tsx
@@ -1,92 +1,26 @@
-import {
-  ChangeEventHandler,
-  FormEventHandler,
-  MouseEventHandler,
-  useEffect,
-  useRef,
-  useState,
-} from "react";
-import { useNavigate, useSearchParams } from "react-router-dom";
-import "../../asset/css/SearchBar.css";
-import BarCodeIcon from "../../asset/img/barcode.svg";
-import SearchIcon from "../../asset/img/search_icon_black.svg";
+import { ComponentProps } from "react";
+import SearchBarInput from "~/component/utils/SearchBarInput";
+import SearchBarButton from "~/component/utils/SearchBarButton";
+import "~/asset/css/SearchBar.css";
 
-type Props = {
-  setQuery?: (query: string) => void;
-  placeHolder?: string;
-  wrapperClassName?: string;
-  width: "banner" | "center" | "short" | "long";
-  isWithBarcodeButton?: boolean;
-  onClickBarcodeButton?: MouseEventHandler<HTMLButtonElement>;
-  isNavigate?: boolean;
-  isFocusedOnMount?: boolean;
+export type Props = ComponentProps<"form"> & {
+  width?: "banner" | "center" | "short" | "long";
 };
 
 const SearchBar = ({
-  setQuery,
-  placeHolder = "",
-  wrapperClassName = "",
-  width,
-  isWithBarcodeButton = false,
-  onClickBarcodeButton = () => {},
-  isNavigate = false,
-  isFocusedOnMount = true,
+  width = "banner",
+  className = "",
+  children,
+  ...rest
 }: Props) => {
-  const [urlParams] = useSearchParams();
-  const [searchWord, setSearchWord] = useState(urlParams.get("search") || "");
-  const navigate = useNavigate();
-  const searchRef = useRef<HTMLInputElement>(null);
-
-  const onChange: ChangeEventHandler<HTMLInputElement> = event => {
-    const { value } = event.currentTarget;
-    if (typeof setQuery === "function") {
-      if (!isNavigate) setQuery(value);
-    }
-    setSearchWord(value);
-  };
-
-  const onSubmit: FormEventHandler = event => {
-    event.preventDefault();
-    const encodedSearchWord = encodeURIComponent(searchWord);
-    if (isNavigate) navigate(`/search?search=${encodedSearchWord}`);
-  };
-
-  useEffect(() => {
-    if (isFocusedOnMount && searchRef.current) {
-      searchRef.current.focus();
-    }
-  }, []);
-
   return (
-    <form
-      className={`search-bar__wrapper ${width} ${wrapperClassName}`}
-      onSubmit={onSubmit}
-    >
-      <input
-        className="search-bar__input"
-        required
-        type="text"
-        autoComplete="off"
-        placeholder={placeHolder}
-        value={searchWord}
-        onChange={onChange}
-        ref={searchRef}
-      />
-      {isWithBarcodeButton ? (
-        <button
-          type="button"
-          className="search-bar__button barcode"
-          onClick={onClickBarcodeButton}
-          aria-label="바코드"
-        >
-          <img src={BarCodeIcon} alt="" />
-        </button>
-      ) : null}
-      <button className="search-bar__button" type="submit" aria-label="검색">
-        <img src={SearchIcon} alt="" />
-      </button>
+    <form {...rest} className={`search-bar__wrapper ${width} ${className}`}>
+      {children}
     </form>
   );
 };
 
 export default SearchBar;
+
+SearchBar.Input = SearchBarInput;
+SearchBar.Button = SearchBarButton;

--- a/src/component/utils/SearchBar.tsx
+++ b/src/component/utils/SearchBar.tsx
@@ -1,6 +1,7 @@
 import { ComponentProps } from "react";
 import SearchBarInput from "~/component/utils/SearchBarInput";
 import SearchBarButton from "~/component/utils/SearchBarButton";
+import SearchBarDropDown from "~/component/utils/SearchBarDropDown";
 import "~/asset/css/SearchBar.css";
 
 export type Props = ComponentProps<"form"> & {
@@ -24,3 +25,4 @@ export default SearchBar;
 
 SearchBar.Input = SearchBarInput;
 SearchBar.Button = SearchBarButton;
+SearchBar.DropDown = SearchBarDropDown;

--- a/src/component/utils/SearchBarButton.tsx
+++ b/src/component/utils/SearchBarButton.tsx
@@ -1,0 +1,12 @@
+import SearchIcon from "~/asset/img/search_icon_black.svg";
+import Image from "~/component/utils/Image";
+
+const SearchBarButton = () => {
+  return (
+    <button className="search-bar__button" type="submit" aria-label="검색">
+      <Image className="search-bar__button" src={SearchIcon} alt="" />
+    </button>
+  );
+};
+
+export default SearchBarButton;

--- a/src/component/utils/SearchBarDropDown.tsx
+++ b/src/component/utils/SearchBarDropDown.tsx
@@ -1,0 +1,50 @@
+import {
+  Dispatch,
+  ReactNode,
+  RefObject,
+  SetStateAction,
+  useEffect,
+  useRef,
+} from "react";
+import "~/asset/css/SearchBarDropDown.css";
+
+type Props = {
+  isOpened: boolean;
+  setIsOpened: Dispatch<SetStateAction<boolean>>;
+  searchBarRef: RefObject<HTMLInputElement>;
+  children: ReactNode;
+};
+const SearchBarDropDown = ({
+  isOpened,
+  setIsOpened,
+  searchBarRef,
+  children,
+}: Props) => {
+  const dropDownRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const closeWhenClickedOutside = (e: MouseEvent) => {
+      if (
+        searchBarRef.current &&
+        dropDownRef.current &&
+        !searchBarRef.current.contains(e.target as Node) &&
+        !dropDownRef.current.contains(e.target as Node)
+      )
+        setIsOpened(false);
+    };
+    document.addEventListener("click", closeWhenClickedOutside);
+    return () => {
+      document.removeEventListener("click", closeWhenClickedOutside);
+    };
+  }, []);
+
+  if (isOpened)
+    return (
+      <div ref={dropDownRef} className="search-bar__dropdown">
+        {children}
+      </div>
+    );
+  return null;
+};
+
+export default SearchBarDropDown;

--- a/src/component/utils/SearchBarDropDown.tsx
+++ b/src/component/utils/SearchBarDropDown.tsx
@@ -32,9 +32,16 @@ const SearchBarDropDown = ({
       )
         setIsOpened(false);
     };
+
+    const closeWithEsc = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsOpened(false);
+    };
+
     document.addEventListener("click", closeWhenClickedOutside);
+    document.addEventListener("keydown", closeWithEsc);
     return () => {
       document.removeEventListener("click", closeWhenClickedOutside);
+      document.removeEventListener("keydown", closeWithEsc);
     };
   }, []);
 

--- a/src/component/utils/SearchBarInput.tsx
+++ b/src/component/utils/SearchBarInput.tsx
@@ -1,0 +1,20 @@
+import { ComponentProps, forwardRef } from "react";
+
+export type Props = Omit<ComponentProps<"input">, "onSubmit">;
+const SearchBarInput = forwardRef<HTMLInputElement, Props>(
+  ({ ...rest }, ref) => {
+    return (
+      <input
+        {...rest}
+        id="input"
+        className="search-bar__input"
+        required
+        type="text"
+        autoComplete="off"
+        ref={ref}
+      />
+    );
+  },
+);
+
+export default SearchBarInput;

--- a/src/component/utils/SearchModal.tsx
+++ b/src/component/utils/SearchModal.tsx
@@ -1,5 +1,5 @@
 import { MouseEventHandler, ReactNode, useRef } from "react";
-import SearchBar from "./SearchBar";
+import ManagementSearchBar from "./ManagementSearchBar";
 import Pagination from "./Pagination";
 import TextWithLabel from "./TextWithLabel";
 import "../../asset/css/SearchModal.css";
@@ -37,7 +37,7 @@ const SearchModal = ({
           mainText={titleText}
           wrapperClassName="search-modal__header__title"
         />
-        <SearchBar
+        <ManagementSearchBar
           setQuery={setQuery}
           width="long"
           isWithBarcodeButton={isWithBarcodeButton}


### PR DESCRIPTION
# 개요
검색창을 Compound 패턴으로 개선합니다
https://www.patterns.dev/posts/compound-pattern

## 목적
### 기존 SearchBar의 복잡성 개선
  - SearchBar 컴포넌트는 여러 상황을 대비해서 다양한 props를 요구하고 props에 맞게 UI를 구성해왔습니다.
  - 또다른 UI 추가 및 변경을 하려면 내부 로직을 변형하여 사용해야 합니다 이 경우 기존 UI에 영향을 주지는 않는지 계속 확인해야 합니다
  - compound pattern을 적용해서 확장에 유연하도록 개선합니다

### 메인페이지와 검색페이지에서만 쓰이는 BookSearchBar 분리
  - 최근검색어, 검색 결과 미리보기 같은 도서 검색에서만 쓰이는 기능을 가진 컴포넌트가 필요합니다
  - 어드민의 검색창은 영향을 받지 않도록 분리합니다

## 변경사항
### SearchBar => BookSearchBar, ManagementSearchBar 변경
- BookSearchBar와 ManagementBar는 용도에 따라 SearchBar에 필요한 기능을 넣은 컴포넌트
- SearchBar는 Input, button, dropwon 등 하위 구성요소를 가짐, 하위 구성요소의 다양한 조합으로 활용가능

### 검색창 드롭다운 추가
- BookSearchBar는 Focus되었을때 드롭다운이 보이고 검색어의 유무에 따라 최근검색어/검색결과미리보기를 보임
- 반응형 변화에 맞춰 적절한 위치에 보입니다

### Preview
![Aug-20-2023 22-11-14](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/3811806b-6c68-40c9-874e-203c6a8d850d)
![Aug-20-2023 22-09-48](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/1bbfe430-83a2-4ad2-bb91-9d43710ee41e)

- fixes #550 
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
