### PR TITLE
feat: 최근 검색어 기능 구현

### DIFF
--- a/src/asset/css/BookSearchRecentKeyword.css
+++ b/src/asset/css/BookSearchRecentKeyword.css
@@ -17,10 +17,15 @@
   width: 100%;
   font-size: 1.4rem;
   gap: 0.8rem;
+  padding-right: 1rem;
 }
 
 .recent-keyword__keyword {
   position: relative;
+  white-space: wrap;
+  word-break: break-all;
+  display: flex;
+  align-items: center;
 }
 
 .recent-keyword__keyword > a {
@@ -36,8 +41,6 @@
   cursor: pointer;
   position: absolute;
   right: 0;
-  top: 50%;
-  transform: translateY(-50%);
   padding: 1rem;
 }
 .recent-keyword__remove > img {

--- a/src/asset/css/BookSearchRecentKeyword.css
+++ b/src/asset/css/BookSearchRecentKeyword.css
@@ -1,0 +1,55 @@
+.recent-keyword__wrapper {
+  padding: 0.8rem 0.4rem;
+  display: flex;
+}
+
+.recent-keyword__wrapper > h3 {
+  font-size: 1.6rem;
+  font-weight: bold;
+  margin-right: 2rem;
+  flex-shrink: 0;
+  margin: 1.6rem 1.2rem;
+}
+
+.recent-keyword__list {
+  display: flex;
+  flex-wrap: wrap;
+  width: 100%;
+  font-size: 1.4rem;
+  gap: 0.8rem;
+}
+
+.recent-keyword__keyword {
+  position: relative;
+}
+
+.recent-keyword__keyword > a {
+  display: inline-block;
+  padding: 0.8rem 3.2rem 0.8rem 1.6rem;
+  border-radius: 1.6rem;
+  background: #d9d9d9;
+}
+
+.recent-keyword__remove {
+  background: none;
+  border: none;
+  cursor: pointer;
+  position: absolute;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 1rem;
+}
+.recent-keyword__remove > img {
+  width: 1rem;
+  height: 1rem;
+}
+.recent-keyword__remove:hover:after {
+  content: "   ";
+  width: 20px;
+  height: 20px;
+  background: #d9d9d9;
+}
+.recet-keyword__no-record {
+  margin: 0.8rem;
+}

--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -36,6 +36,7 @@ const BookSearchBar = () => {
         onChange={e => setKeyword(e.target.value)}
         onFocus={() => setIsOpened(true)}
         ref={ref}
+        maxLength={80}
       />
       <SearchBar.DropDown
         isOpened={isOpened}

--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -14,6 +14,12 @@ const BookSearchBar = () => {
   const goToSearchPage: FormEventHandler<HTMLFormElement> = e => {
     e.preventDefault();
     const searchWord = e.currentTarget.input.value;
+    const storageSaved = localStorage.getItem("recent") || "[]";
+    const recentKeywords = JSON.parse(storageSaved);
+    if (!recentKeywords.includes(searchWord)) {
+      recentKeywords.unshift(searchWord);
+      localStorage.setItem("recent", JSON.stringify(recentKeywords));
+    }
     navigate(`/search?search=${encodeURIComponent(searchWord)}`);
     e.currentTarget.input.blur();
   };

--- a/src/component/utils/BookSearchRecentKeywords.tsx
+++ b/src/component/utils/BookSearchRecentKeywords.tsx
@@ -1,5 +1,47 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import Image from "~/component/utils/Image";
+import X_button from "~/asset/img/x_button.svg";
+import "~/asset/css/BookSearchRecentKeyword.css";
+
 const BookSearchRecentKeyword = () => {
-  return <div>최근 검색어</div>;
+  const storageSaved = localStorage.getItem("recent") || "[]";
+  const [keywords, setKeywords] = useState<string[]>(JSON.parse(storageSaved));
+
+  const removeKeyword = (keyword: string) => {
+    const newKeywords = keywords.filter(k => k !== keyword);
+    localStorage.setItem("recent", JSON.stringify(newKeywords));
+    setKeywords(newKeywords);
+  };
+
+  return (
+    <div className="recent-keyword__wrapper">
+      <h3>최근 검색어</h3>
+      <ul className="recent-keyword__list">
+        {keywords.map(keyword => (
+          <li key={keyword} className="recent-keyword__keyword">
+            <Link to={`/search?search=${encodeURIComponent(keyword)}`}>
+              <p>{keyword}</p>
+            </Link>
+            <button
+              className="recent-keyword__remove"
+              onClick={e => {
+                e.stopPropagation();
+                removeKeyword(keyword);
+              }}
+            >
+              <Image src={X_button} alt="삭제" />
+            </button>
+          </li>
+        ))}
+        {keywords.length === 0 && (
+          <li className="recet-keyword__no-record">
+            최근 검색된 기록이 없습니다
+          </li>
+        )}
+      </ul>
+    </div>
+  );
 };
 
 export default BookSearchRecentKeyword;


### PR DESCRIPTION
# 개요
최근 검색어를 보여줍니다 
- blocked by #551 
- fixed #548

### 주요 기능
- 검색창 focus + 검색어 입력이 없을 시 최근 검색어 목록을 보여줍니다
- 새로운 단어 검색시 최근 검색어에 추가됩니다
- 검색어 옆 X 버튼으로 삭제할 수 있습니다
- 검색어를 클릭하면 해당 검색 결과를 볼 수 있습니다

### Preview
||이미지|
|---|---|
|검색어 추가 및 검색 결과로 이동|![Aug-21-2023 15-20-16](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/ee58bae7-89a8-415a-9cf6-a9b5bf453af4)| 
|이미 최근 검색어에 있을시 추가되지 않음|![Aug-21-2023 16-04-22](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/fee12847-e947-4645-b766-2d4db9da1ccf)|
|검색어 삭제|![Aug-21-2023 15-25-56](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/7ceef9ae-e8f8-48c9-9942-778d239bc5a2)|
|검색어 길이가 긴 경우|![Aug-21-2023 15-28-23](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/ba987715-e854-4c14-bb6a-8f3e398defe6)|
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
