### PR TITLE
feat: carousel UI 컴포넌트 추가 및 메인페이지에 적용

### DIFF
--- a/src/asset/css/Carousel.css
+++ b/src/asset/css/Carousel.css
@@ -10,4 +10,5 @@
 .carousel__list > * {
   display: block;
   box-sizing: border-box;
+  flex: 0 0;
 }

--- a/src/asset/css/Carousel.css
+++ b/src/asset/css/Carousel.css
@@ -1,0 +1,13 @@
+.carousel__container {
+  overflow: hidden;
+  position: relative;
+}
+
+.carousel__list {
+  display: flex;
+}
+
+.carousel__list > * {
+  display: block;
+  box-sizing: border-box;
+}

--- a/src/asset/css/MainNew.css
+++ b/src/asset/css/MainNew.css
@@ -12,7 +12,7 @@
 .main-new__arrow {
   margin: 0;
   position: absolute;
-  top: 27.5rem;
+  top: 10rem;
   left: 0;
   background-color: rgba(0, 0, 0, 0.4);
   border: none;
@@ -34,12 +34,7 @@
   position: relative;
   z-index: 0;
   width: 100%;
-  overflow: hidden;
   margin-top: 10rem;
-}
-
-.main-new__books {
-  transition: all 0.3s ease-in-out;
 }
 
 .main-new__book {
@@ -78,10 +73,9 @@
 }
 
 .main-new__books_pagination {
-  position: absolute;
-  bottom: 0;
-  left: 50%;
-  transform: translateX(-50%);
+  display: flex;
+  justify-content: center;
+  margin-top: 10rem;
 }
 
 .main-new__books_pag_circle {
@@ -105,7 +99,7 @@
   background-color: #2d2d2d;
 }
 
-@media screen and (max-width:767px) {
+@media screen and (max-width: 767px) {
   .main-new {
     height: 52rem;
   }

--- a/src/asset/css/MainNew.css
+++ b/src/asset/css/MainNew.css
@@ -12,7 +12,7 @@
 .main-new__arrow {
   margin: 0;
   position: absolute;
-  top: 10rem;
+  bottom: 10rem;
   left: 0;
   background-color: rgba(0, 0, 0, 0.4);
   border: none;

--- a/src/component/main/MainNewBook.tsx
+++ b/src/component/main/MainNewBook.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
-import Image from "../utils/Image";
-import { BookInfo } from "../../type";
+import type { BookInfo } from "~/type";
+import Image from "~/component/utils/Image";
 
 type Props = {
   book: BookInfo;
@@ -9,19 +9,19 @@ type Props = {
 
 const MainNewBook = ({ book, bookWidth }: Props) => {
   return (
-    <div
+    <Link
       className="main-new__book"
+      to={`/info/${book.id}`}
+      state={{ bread: "신간 도서" }}
       style={{ width: bookWidth, height: bookWidth * 1.5 }}
     >
-      <Link to={`/info/${book.id}`} state={{ bread: "신간 도서" }}>
-        <Image
-          width={bookWidth}
-          height={bookWidth * 1.5}
-          src={book.image}
-          alt="new"
-        />
-      </Link>
-    </div>
+      <Image
+        width={bookWidth}
+        height={bookWidth * 1.5}
+        src={book.image}
+        alt="new"
+      />
+    </Link>
   );
 };
 

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -51,7 +51,7 @@ const MainNewBookList = ({ docs }: Props) => {
         showPreviousItem="half"
         items={docs}
         renderItem={({ item }) => (
-          <MainNewBook book={item} bookWidth={bookWidth} />
+          <MainNewBook book={item} key={item.key} bookWidth={bookWidth} />
         )}
       />
       <Carousel.Pagination

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -25,11 +25,20 @@ const MainNewBookList = ({ docs }: Props) => {
 
   return (
     <Carousel.Root
-      className="main-new__container"
       length={docs.length}
       itemSize={bookWidth + margin}
       delay={2000}
     >
+      <Carousel.Container className="main-new__container">
+        <Carousel.List
+          className="main-new__booklist"
+          showPreviousItem="half"
+          items={docs}
+          renderItem={({ item }) => (
+            <MainNewBook book={item} key={item.key} bookWidth={bookWidth} />
+          )}
+        />
+      </Carousel.Container>
       <Carousel.Prev className="main-new__arrow">
         <Image
           src={ArrLeft}
@@ -46,14 +55,6 @@ const MainNewBookList = ({ docs }: Props) => {
           height={moveButton.height}
         />
       </Carousel.Next>
-      <Carousel.List
-        className="main-new__booklist"
-        showPreviousItem="half"
-        items={docs}
-        renderItem={({ item }) => (
-          <MainNewBook book={item} key={item.key} bookWidth={bookWidth} />
-        )}
-      />
       <Carousel.Pagination
         className="main-new__pagination"
         render={({ page, setPage }) => (

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -6,31 +6,34 @@ import ArrLeft from "../../asset/img/arrow_left.svg";
 import ArrRight from "../../asset/img/arrow_right.svg";
 import { BookInfo } from "../../type";
 import { useInterval } from "~/hook/useInterval";
-
-const mobileWidth = 100;
-const pcWidth = 200;
+import { useResponsiveWidth } from "~/hook/useResponsiveWidth";
 
 type Props = {
   docs: BookInfo[];
 };
 
 const MainNewBookList = ({ docs }: Props) => {
+  const { width: bookWidth } = useResponsiveWidth({
+    pcWidth: 200,
+    mobileWidth: 100,
+  });
+
   const [page, setPage] = useState(1);
-  const [bookWidth, setBookWidth] = useState(pcWidth);
   const [transition, setTransition] = useState(true);
   const [displayCount, setDisplayCount] = useState(0);
 
   useEffect(() => {
     function handleSize() {
+      const mobileWidth = 100;
+      const pcWidth = 200;
       const width = window.innerWidth < 767 ? mobileWidth : pcWidth;
-      if (width !== bookWidth) setBookWidth(width);
       const count = Math.ceil(window.innerWidth / (width * 1.1));
       if (count !== displayCount) setDisplayCount(count);
     }
     window.addEventListener("resize", handleSize);
     handleSize();
     return () => window.removeEventListener("resize", handleSize);
-  }, [bookWidth, displayCount]);
+  }, [displayCount]);
 
   const books = [...docs.slice(-1), ...docs, ...docs.slice(0, displayCount)];
   const onNext = () => {

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -1,12 +1,11 @@
-import { useState, useEffect, useRef } from "react";
-import MainNewBook from "./MainNewBook";
-import MainNewBookPagination from "./MainNewBookPagination";
-import Image from "../utils/Image";
-import ArrLeft from "../../asset/img/arrow_left.svg";
-import ArrRight from "../../asset/img/arrow_right.svg";
-import { BookInfo } from "../../type";
-import { useInterval } from "~/hook/useInterval";
+import type { BookInfo } from "~/type";
 import { useResponsiveWidth } from "~/hook/useResponsiveWidth";
+import Carousel from "~/component/utils/Carousel";
+import Image from "~/component/utils/Image";
+import MainNewBook from "~/component/main/MainNewBook";
+import MainNewBookPagination from "~/component/main/MainNewBookPagination";
+import ArrLeft from "~/asset/img/arrow_left.svg";
+import ArrRight from "~/asset/img/arrow_right.svg";
 
 type Props = {
   docs: BookInfo[];
@@ -18,99 +17,50 @@ const MainNewBookList = ({ docs }: Props) => {
     mobileWidth: 100,
   });
 
-  const [page, setPage] = useState(1);
-  const [transition, setTransition] = useState(true);
-  const [displayCount, setDisplayCount] = useState(0);
-
-  useEffect(() => {
-    function handleSize() {
-      const mobileWidth = 100;
-      const pcWidth = 200;
-      const width = window.innerWidth < 767 ? mobileWidth : pcWidth;
-      const count = Math.ceil(window.innerWidth / (width * 1.1));
-      if (count !== displayCount) setDisplayCount(count);
-    }
-    window.addEventListener("resize", handleSize);
-    handleSize();
-    return () => window.removeEventListener("resize", handleSize);
-  }, [displayCount]);
-
-  const books = [...docs.slice(-1), ...docs, ...docs.slice(0, displayCount)];
-  const onNext = () => {
-    const index = page;
-    if (index === books.length - displayCount - 1) {
-      setTransition(false);
-      setPage(0);
-      setTimeout(() => {
-        setTransition(true);
-        setPage(1);
-      }, 3);
-    } else setPage(index + 1);
+  const margin = 10;
+  const moveButton = {
+    width: bookWidth / 4,
+    height: bookWidth * 1.5 + 20,
   };
-
-  const onPrev = () => {
-    let index = page;
-    if (index === 1) {
-      index = books.length - displayCount;
-      setTransition(false);
-      setPage(index);
-      setTimeout(() => {
-        setTransition(true);
-        setPage(index - 1);
-      }, 3);
-    } else setPage(index - 1);
-  };
-
-  const { startInterval, stopInterval } = useInterval(onNext, 2000);
 
   return (
-    <div className="main-new__content">
-      <button
-        className="main-new__arrow"
-        onClick={onPrev}
-        type="button"
-        onMouseEnter={stopInterval}
-        onMouseLeave={startInterval}
-      >
+    <Carousel.Root
+      className="main-new__container"
+      length={docs.length}
+      itemSize={bookWidth + margin * 2}
+      delay={2000}
+    >
+      <Carousel.Prev className="main-new__arrow">
         <Image
           src={ArrLeft}
-          alt=""
-          width={bookWidth / 4}
-          height={bookWidth * 1.5 + 20}
+          alt="이전"
+          width={moveButton.width}
+          height={moveButton.height}
         />
-      </button>
-      <button
-        className="main-new__arrow right"
-        onClick={onNext}
-        type="button"
-        onMouseEnter={stopInterval}
-        onMouseLeave={startInterval}
-      >
+      </Carousel.Prev>
+      <Carousel.Next className="main-new__arrow right">
         <Image
           src={ArrRight}
-          alt=""
-          width={bookWidth / 4}
-          height={bookWidth * 1.5 + 20}
+          alt="다음"
+          width={moveButton.width}
+          height={moveButton.height}
         />
-      </button>
-      <div className="main-new__booklist">
-        <div
-          className={`${transition && "main-new__books"}`}
-          style={{
-            transform: `translate(${
-              +((bookWidth / 2) * 0.1) - bookWidth * 1.1 * page * 0.1
-            }rem)`,
-          }}
-          onMouseEnter={stopInterval}
-          onMouseLeave={startInterval}
-        >
-          {books.map(book => (
-            <MainNewBook book={book} bookWidth={bookWidth} />
-          ))}
-        </div>
-      </div>
-      <MainNewBookPagination page={page} setPage={setPage} />
-    </div>
+      </Carousel.Next>
+      <Carousel.List
+        className="main-new__booklist"
+        showPreviousItem="half"
+        items={docs}
+        renderItem={({ item }) => (
+          <MainNewBook book={item} bookWidth={bookWidth} />
+        )}
+      />
+      <Carousel.Pagination
+        className="main-new__pagination"
+        render={({ page, setPage }) => (
+          <MainNewBookPagination page={page} setPage={setPage} />
+        )}
+      />
+    </Carousel.Root>
   );
 };
 

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -17,7 +17,7 @@ const MainNewBookList = ({ docs }: Props) => {
     mobileWidth: 100,
   });
 
-  const margin = 10;
+  const margin = bookWidth * 0.1;
   const moveButton = {
     width: bookWidth / 4,
     height: bookWidth * 1.5 + 20,
@@ -27,7 +27,7 @@ const MainNewBookList = ({ docs }: Props) => {
     <Carousel.Root
       className="main-new__container"
       length={docs.length}
-      itemSize={bookWidth + margin * 2}
+      itemSize={bookWidth + margin}
       delay={2000}
     >
       <Carousel.Prev className="main-new__arrow">

--- a/src/component/main/MainNewBookList.tsx
+++ b/src/component/main/MainNewBookList.tsx
@@ -5,6 +5,7 @@ import Image from "../utils/Image";
 import ArrLeft from "../../asset/img/arrow_left.svg";
 import ArrRight from "../../asset/img/arrow_right.svg";
 import { BookInfo } from "../../type";
+import { useInterval } from "~/hook/useInterval";
 
 const mobileWidth = 100;
 const pcWidth = 200;
@@ -18,7 +19,6 @@ const MainNewBookList = ({ docs }: Props) => {
   const [bookWidth, setBookWidth] = useState(pcWidth);
   const [transition, setTransition] = useState(true);
   const [displayCount, setDisplayCount] = useState(0);
-  const intervalId = useRef<NodeJS.Timer>();
 
   useEffect(() => {
     function handleSize() {
@@ -58,19 +58,7 @@ const MainNewBookList = ({ docs }: Props) => {
     } else setPage(index - 1);
   };
 
-  const pauseInterval = () => {
-    clearInterval(intervalId.current);
-  };
-  const startInterval = () => {
-    clearInterval(intervalId.current);
-    intervalId.current = setInterval(onNext, 2000);
-  };
-
-  useEffect(() => {
-    clearInterval(intervalId.current);
-    intervalId.current = setInterval(onNext, 2000);
-    return () => clearInterval(intervalId.current);
-  }, [page]);
+  const { startInterval, stopInterval } = useInterval(onNext, 2000);
 
   return (
     <div className="main-new__content">
@@ -78,7 +66,7 @@ const MainNewBookList = ({ docs }: Props) => {
         className="main-new__arrow"
         onClick={onPrev}
         type="button"
-        onMouseEnter={pauseInterval}
+        onMouseEnter={stopInterval}
         onMouseLeave={startInterval}
       >
         <Image
@@ -92,7 +80,7 @@ const MainNewBookList = ({ docs }: Props) => {
         className="main-new__arrow right"
         onClick={onNext}
         type="button"
-        onMouseEnter={pauseInterval}
+        onMouseEnter={stopInterval}
         onMouseLeave={startInterval}
       >
         <Image
@@ -110,7 +98,7 @@ const MainNewBookList = ({ docs }: Props) => {
               +((bookWidth / 2) * 0.1) - bookWidth * 1.1 * page * 0.1
             }rem)`,
           }}
-          onMouseEnter={pauseInterval}
+          onMouseEnter={stopInterval}
           onMouseLeave={startInterval}
         >
           {books.map(book => (

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -1,4 +1,5 @@
 import {
+  CSSProperties,
   ComponentProps,
   createContext,
   useContext,
@@ -138,7 +139,11 @@ const Root = ({
 
 type ListProps<T extends { id: number }> = ComponentProps<"ul"> & {
   items: T[];
-  renderItem: (props: { item: T & { key: string } }) => JSX.Element;
+  renderItem: (props: {
+    item: T;
+    key: string;
+    style: CSSProperties;
+  }) => JSX.Element;
   showPreviousItem?: "half" | "none";
 };
 
@@ -193,7 +198,9 @@ const List = <T extends { id: number }>({
       onMouseOver={pauseAutoAnimation}
       onMouseLeave={startAutoAnimation}
     >
-      {displayItems.map(item => renderItem({ item }))}
+      {displayItems.map(item =>
+        renderItem({ item, key: item.key, style: { flexBasis: itemSize } }),
+      )}
     </ul>
   );
 };

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -164,20 +164,22 @@ const List = <T extends { id: number }>({
   const displayItems = useMemo(() => {
     if (items.length === 0) return [];
     const lastItem = items.slice(-1)[0];
+    const copySize =
+      displayCount >= items.length ? displayCount / items.length + 1 : 0;
     return [
       { ...lastItem, key: "last" + lastItem.id },
       ...items.map(i => ({ ...i, key: `${i.id}` })),
-      ...Array.from({ length: displayCount / items.length + 1 }).flatMap(
-        (_, i) =>
-          items.map((_, index) => ({
-            ...items[index % items.length],
-            key: "copy" + i + index, //  key 중복을 피하기 위해 임의로 가공
-          })),
+      ...Array.from({ length: copySize }).flatMap((_, i) =>
+        items.map((_, index) => ({
+          ...items[index % items.length],
+          key: "copy" + i + index, //  key 중복을 피하기 위해 임의로 가공
+        })),
       ),
     ];
   }, [items, displayCount]);
 
   const prevItemSize = showPreviousItem === "half" ? itemSize / 2 : 0;
+  const translate = direction === "row" ? "translateX" : "translateY";
 
   return (
     <ul
@@ -185,7 +187,7 @@ const List = <T extends { id: number }>({
       className={`carousel__list ${className}`}
       style={{
         // 슬라이더의 이동을 위해 transform을 사용한다.
-        transform: `translate(-${itemSize * index + prevItemSize / 2}px)`,
+        transform: `${translate}(-${itemSize * index + prevItemSize / 2}px)`,
         flexDirection: direction === "row" ? "row" : "column",
         transition: isSmoothAnimated ? "transform 0.2s ease-in-out" : "",
       }}

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -1,0 +1,228 @@
+import {
+  ComponentProps,
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+} from "react";
+import { useInterval } from "~/hook/useInterval";
+import { useBound } from "~/hook/useBound";
+import "~/asset/css/Carousel.css";
+
+// 내부 컴포넌트에서 사용하는 context
+const CarouselContext = createContext({
+  index: 0,
+  isAnimated: true,
+  onPrev: () => {},
+  onNext: () => {},
+  setIndex: (index: number) => {},
+  startInterval: () => {},
+  stopInterval: () => {},
+  displayCount: 0,
+  itemSize: 0,
+  length: 0,
+  direction: "row",
+});
+
+/**
+ * Carousel 무한 슬라이드를 위한 컴포넌트
+ * @param length -  슬라이드 될 item의 개수
+ * @param itemSize - 슬라이드 될 item의 크기, margin 포함 실제 크기(px)로 실제 이동하는 거리와 같음
+ * @param direction - 슬라이드 방향 (row | column)
+ * @param delay - 슬라이드 간의 시간 간격
+ */
+
+type Props = ComponentProps<"div"> & {
+  length: number;
+  itemSize: number;
+  direction?: "row" | "column";
+  delay?: number;
+};
+
+const Root = ({
+  length,
+  itemSize,
+  direction = "row",
+  delay = 2000,
+  children,
+  className = "",
+  ...rest
+}: Props) => {
+  const [slide, setSlide] = useState({ index: 1, isAnimated: true }); // 슬라이드 움직임 제어
+
+  const { targetRef, boundInfo: bound } = useBound<HTMLDivElement>({
+    hasResizeEvent: true,
+    hasScrollEvent: false,
+  }); // 슬라이드 컨테이너의 전체 크기 확인
+  const containerSize = direction === "row" ? bound.width : bound.height;
+  const displayCount = Math.floor(containerSize / itemSize); // 슬라이드에 들어가야 할 item의 총 개수 (화면에 보여지는 개수)
+
+  // 무한 슬라이드를 위한 index 이동 설정
+  const onNext = () => {
+    // 슬라이드가 처음이나 끝에서 이동할 때는 애니메이션 효과를 없애고, 이동 후에 애니메이션 효과를 적용한다.
+    // 마지막 요소가 첫번째 앞에 추가되었기 때문에 length - 1 대신 length로 이동
+    if (slide.index === length) {
+      setSlide({ index: 0, isAnimated: false });
+      setTimeout(() => setSlide({ index: 1, isAnimated: true }), delay / 100);
+    } else setSlide({ index: slide.index + 1, isAnimated: true });
+  };
+
+  const onPrev = () => {
+    if (slide.index === 0) {
+      // 마찬가지로 length - 1 대신 length로 이동
+      setSlide({ index: length, isAnimated: false });
+      setTimeout(
+        () => setSlide({ index: length - 1, isAnimated: true }),
+        delay / 100,
+      );
+    } else setSlide({ index: slide.index - 1, isAnimated: true });
+  };
+
+  // 슬라이드 자동 이동 및 Hover시 멈추기 위한 함수
+  const { startInterval, stopInterval } = useInterval(onNext, delay);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        index: slide.index,
+        isAnimated: slide.isAnimated,
+        onNext,
+        onPrev,
+        setIndex: (index: number) => setSlide(prev => ({ ...prev, index })),
+        startInterval,
+        stopInterval,
+        displayCount,
+        itemSize,
+        length,
+        direction,
+      }}
+    >
+      <div
+        {...rest}
+        className={`carousel__container ${className}`}
+        ref={targetRef}
+        onMouseEnter={stopInterval}
+        onMouseLeave={startInterval}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  );
+};
+
+/**
+ * 슬라이드 될 item들을 보여주는 컴포넌트
+ * Carousel.Root 컴포넌트로 감싸져야 한다.
+ *
+ * @param items - 슬라이드 될 item들의 배열
+ * @param renderItem - 슬라이드 될 item의 렌더링 UI, 파라미터로 item을 받아서 렌더링한다.
+ * @param showPreviousItem - 이전 item을 보여줄지 여부 (half | none)
+ * @example ~/component/main/MainNewBookList.tsx
+ */
+
+type ListProps<T extends { id: number }> = ComponentProps<"ul"> & {
+  items: T[];
+  renderItem: (props: ComponentProps<"a"> & { item: T }) => React.ReactNode;
+  showPreviousItem?: "half" | "none";
+};
+
+const List = <T extends { id: number }>({
+  items,
+  renderItem,
+  showPreviousItem = "none",
+  className,
+  ...rest
+}: ListProps<T>) => {
+  const {
+    index,
+    startInterval,
+    stopInterval,
+    displayCount,
+    itemSize,
+    direction,
+    isAnimated,
+  } = useContext(CarouselContext);
+
+  // 슬라이드 될 item들을 복사해서 앞뒤로 붙여준다.
+  // 애니메이션 효과를 위한 앞 마지막 1개와 컨테이너 크기에 맞춰서 복사한 item들을 붙여준다.
+  const displayItems = useMemo(() => {
+    if (items.length === 0) return [];
+    const lastItem = items.slice(-1)[0];
+    return [
+      { ...lastItem, key: "last" + lastItem.id },
+      ...items.map(i => ({ ...i, key: `${i.id}` })),
+      ...Array.from({ length: displayCount / items.length + 1 }).flatMap(
+        (_, i) =>
+          items.map((_, index) => ({
+            ...items[index % items.length],
+            key: "copy" + i + index, //  key 중복을 피하기 위해 임의로 가공
+          })),
+      ),
+    ];
+  }, [items, displayCount]);
+
+  const prevItemSize = showPreviousItem === "half" ? itemSize / 2 : 0;
+
+  return (
+    <ul
+      {...rest}
+      className={`carousel__list ${className}`}
+      style={{
+        // 슬라이더의 이동을 위해 transform을 사용한다.
+        transform: `translate(-${itemSize * index + prevItemSize / 2}px)`,
+        flexDirection: direction === "row" ? "row" : "column",
+        transition: isAnimated ? "transform 0.2s ease-in-out" : "",
+      }}
+      onMouseOver={stopInterval}
+      onMouseLeave={startInterval}
+    >
+      {displayItems.map(item => renderItem({ item, key: item.key }))}
+    </ul>
+  );
+};
+
+const Prev = ({ className, ...rest }: ComponentProps<"button">) => {
+  const { onPrev, startInterval, stopInterval } = useContext(CarouselContext);
+
+  return (
+    <button
+      {...rest}
+      onClick={onPrev}
+      className={`carousel__prev ${className}`}
+      onMouseOver={stopInterval}
+      onMouseLeave={startInterval}
+    />
+  );
+};
+
+const Next = ({ className, ...rest }: ComponentProps<"button">) => {
+  const { onNext, startInterval, stopInterval } = useContext(CarouselContext);
+
+  return (
+    <button
+      {...rest}
+      onClick={onNext}
+      className={`carousel__next ${className}`}
+      onMouseOver={stopInterval}
+      onMouseLeave={startInterval}
+    />
+  );
+};
+
+type PaginationProps = {
+  render: (props: {
+    page: number;
+    setPage: (page: number) => void;
+    lastPage?: number;
+  }) => JSX.Element;
+} & ComponentProps<"div">;
+const Pagination = ({ render }: PaginationProps) => {
+  const { index, setIndex, length } = useContext(CarouselContext);
+  return render({
+    page: index,
+    setPage: setIndex,
+    lastPage: length - 1,
+  });
+};
+
+export default { Root, Prev, Next, List, Pagination };

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -73,8 +73,8 @@ const Root = ({
 
   // 무한 슬라이드를 위한 index 이동 설정
   const onNext = () => {
-    // 슬라이드가 처음이나 끝에서 이동할 때는 애니메이션 효과를 없애고, 이동 후에 애니메이션 효과를 적용한다.
     // 마지막 요소가 첫번째 앞에 추가되었기 때문에 length - 1 대신 length로 이동
+    // 바로 이동하면 동작이 어색함, 애니메이션 효과 false 설정 후 0.01초 뒤에 이동
     if (slide.index === length) {
       setSlide({ index: 0, isSmoothAnimated: false });
       setTimeout(() => setSlide({ index: 1, isSmoothAnimated: true }), 10);
@@ -82,13 +82,9 @@ const Root = ({
   };
 
   const onPrev = () => {
-    if (slide.index === 0) {
-      // 마찬가지로 length - 1 대신 length로 이동
-      setSlide({ index: length, isSmoothAnimated: false });
-      setTimeout(
-        () => setSlide({ index: length - 1, isSmoothAnimated: true }),
-        10,
-      );
+    if (slide.index === 1) {
+      setSlide({ index: length + 1, isSmoothAnimated: false });
+      setTimeout(() => setSlide({ index: length, isSmoothAnimated: true }), 10);
     } else setSlide({ index: slide.index - 1, isSmoothAnimated: true });
   };
 

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -28,20 +28,27 @@ const CarouselContext = createContext({
  * Carousel 무한 슬라이드를 위한 컴포넌트
  * @param length -  슬라이드 될 item의 개수
  * @param itemSize - 슬라이드 될 item의 크기, margin 포함 실제 크기(px)로 실제 이동하는 거리와 같음
+ * @param itemCount - 슬라이드 될 container에 들어갈 item의 개수, 크기는 자동 조정
+ * itemSize나 itemCount 둘 중 하나만 지정가능, 둘 중 하나는 반드시 지정되어야 함
  * @param direction - 슬라이드 방향 (row | column)
  * @param delay - 슬라이드 간의 시간 간격
  */
 
 type Props = ComponentProps<"div"> & {
   length: number;
-  itemSize: number;
+  itemSize?: number;
+  itemCount?: number;
   direction?: "row" | "column";
   delay?: number;
-};
+} & (
+    | { itemSize: number; itemCount?: never }
+    | { itemCount: number; itemSize?: never }
+  );
 
 const Root = ({
   length,
   itemSize,
+  itemCount,
   direction = "row",
   delay = 2000,
   children,
@@ -55,7 +62,10 @@ const Root = ({
     hasScrollEvent: false,
   }); // 슬라이드 컨테이너의 전체 크기 확인
   const containerSize = direction === "row" ? bound.width : bound.height;
-  const displayCount = Math.floor(containerSize / itemSize); // 슬라이드에 들어가야 할 item의 총 개수 (화면에 보여지는 개수)
+  const displayCount = itemSize
+    ? Math.floor(containerSize / itemSize)
+    : itemCount!;
+  // 슬라이드에 들어가야 할 item의 총 개수 (화면에 보여지는 개수)
 
   // 무한 슬라이드를 위한 index 이동 설정
   const onNext = () => {
@@ -92,7 +102,7 @@ const Root = ({
         startInterval,
         stopInterval,
         displayCount,
-        itemSize,
+        itemSize: itemSize ?? containerSize / itemCount!,
         length,
         direction,
       }}
@@ -122,7 +132,7 @@ const Root = ({
 
 type ListProps<T extends { id: number }> = ComponentProps<"ul"> & {
   items: T[];
-  renderItem: (props: ComponentProps<"a"> & { item: T }) => React.ReactNode;
+  renderItem: (props: ComponentProps<any> & { item: T }) => React.ReactNode;
   showPreviousItem?: "half" | "none";
 };
 
@@ -176,7 +186,9 @@ const List = <T extends { id: number }>({
       onMouseOver={stopInterval}
       onMouseLeave={startInterval}
     >
-      {displayItems.map(item => renderItem({ item, key: item.key }))}
+      {displayItems.map(item =>
+        renderItem({ item, key: item.key, style: { flexBasis: itemSize } }),
+      )}
     </ul>
   );
 };

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -164,8 +164,7 @@ const List = <T extends { id: number }>({
   const displayItems = useMemo(() => {
     if (items.length === 0) return [];
     const lastItem = items.slice(-1)[0];
-    const copySize =
-      displayCount >= items.length ? displayCount / items.length + 1 : 0;
+    const copySize = displayCount / items.length + 1;
     return [
       { ...lastItem, key: "last" + lastItem.id },
       ...items.map(i => ({ ...i, key: `${i.id}` })),

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -1,18 +1,30 @@
-import {
-  CSSProperties,
-  ComponentProps,
-  createContext,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from "react";
-import { useInterval } from "~/hook/useInterval";
-import { useBound } from "~/hook/useBound";
+import { RefObject, createContext } from "react";
+import CarouselRoot from "~/component/utils/CarouselRoot";
+import CarouselList from "~/component/utils/CarouselList";
+import CarouselContainer from "~/component/utils/CarouselContainer";
+import CarouselPagination from "~/component/utils/CarouselPagination";
+import CarouselPrev from "./CarouselPrev";
+import CarouselNext from "./CarouselNext";
 import "~/asset/css/Carousel.css";
 
+type CarouselContextType = {
+  index: number;
+  isSmoothAnimated: boolean;
+  onPrev: () => void;
+  onNext: () => void;
+  setIndex: (index: number) => void;
+  startAutoAnimation: () => void;
+  pauseAutoAnimation: () => void;
+  displayCount: number;
+  itemSize: number;
+  length: number;
+  direction: "row" | "column";
+  targetRef: RefObject<HTMLDivElement> | null;
+};
+
 // 내부 컴포넌트에서 사용하는 context
-const CarouselContext = createContext({
+// Root 컴포넌트로 감싼 후 다양한 컴포넌트를 조합해서 활용 가능
+export const CarouselContext = createContext<CarouselContextType>({
   index: 0,
   isSmoothAnimated: true,
   onPrev: () => {},
@@ -24,232 +36,15 @@ const CarouselContext = createContext({
   itemSize: 0,
   length: 0,
   direction: "row",
+  targetRef: null,
 });
 
-/**
- * Carousel 무한 슬라이드를 위한 컴포넌트
- * @param length -  슬라이드 될 item의 개수
- * @param itemSize - 슬라이드 될 item의 크기, margin 포함 실제 크기(px)로 실제 이동하는 거리와 같음
- * @param itemCount - 슬라이드 될 container에 들어갈 item의 개수, 크기는 자동 조정
- * @param isAnimated - 슬라이드 애니메이션 여부
- * itemSize나 itemCount 둘 중 하나만 지정가능, 둘 중 하나는 반드시 지정되어야 함
- * @param direction - 슬라이드 방향 (row | column)
- * @param delay - 슬라이드 간의 시간 간격
- */
+const Carousel = () => {};
 
-type Props = ComponentProps<"div"> & {
-  length: number;
-  itemSize?: number;
-  itemCount?: number;
-  direction?: "row" | "column";
-  delay?: number;
-  isAutoAnimated?: boolean;
-} & (
-    | { itemSize: number; itemCount?: never }
-    | { itemCount: number; itemSize?: never }
-  );
-
-const Root = ({
-  length,
-  itemSize,
-  itemCount,
-  direction = "row",
-  delay = 2000,
-  isAutoAnimated = true,
-  children,
-  className = "",
-  ...rest
-}: Props) => {
-  const [slide, setSlide] = useState({ index: 1, isSmoothAnimated: true }); // 슬라이드 움직임 제어
-
-  const { targetRef, boundInfo: bound } = useBound<HTMLDivElement>({
-    hasResizeEvent: true,
-    hasScrollEvent: false,
-  }); // 슬라이드 컨테이너의 전체 크기 확인
-  const containerSize = direction === "row" ? bound.width : bound.height;
-  const displayCount = itemSize
-    ? Math.floor(containerSize / itemSize)
-    : itemCount!;
-  // 슬라이드에 들어가야 할 item의 총 개수 (화면에 보여지는 개수)
-
-  // 무한 슬라이드를 위한 index 이동 설정
-  const onNext = () => {
-    // 마지막 요소가 첫번째 앞에 추가되었기 때문에 length - 1 대신 length로 이동
-    // 바로 이동하면 동작이 어색함, 애니메이션 효과 false 설정 후 0.01초 뒤에 이동
-    if (slide.index === length) {
-      setSlide({ index: 0, isSmoothAnimated: false });
-      setTimeout(() => setSlide({ index: 1, isSmoothAnimated: true }), 10);
-    } else setSlide({ index: slide.index + 1, isSmoothAnimated: true });
-  };
-
-  const onPrev = () => {
-    if (slide.index === 1) {
-      setSlide({ index: length + 1, isSmoothAnimated: false });
-      setTimeout(() => setSlide({ index: length, isSmoothAnimated: true }), 10);
-    } else setSlide({ index: slide.index - 1, isSmoothAnimated: true });
-  };
-
-  const { startInterval, stopInterval } = useInterval(onNext, delay);
-
-  const startAutoAnimation = () => isAutoAnimated && startInterval();
-  const pauseAutoAnimation = stopInterval;
-
-  useEffect(() => {
-    startAutoAnimation();
-  }, [startAutoAnimation]);
-
-  return (
-    <CarouselContext.Provider
-      value={{
-        index: slide.index,
-        isSmoothAnimated: slide.isSmoothAnimated,
-        onNext,
-        onPrev,
-        setIndex: (index: number) => setSlide(prev => ({ ...prev, index })),
-        startAutoAnimation,
-        pauseAutoAnimation,
-        displayCount,
-        itemSize: itemSize ?? containerSize / itemCount!,
-        length,
-        direction,
-      }}
-    >
-      <div
-        {...rest}
-        className={`carousel__container ${className}`}
-        ref={targetRef}
-        onMouseEnter={pauseAutoAnimation}
-        onMouseLeave={startAutoAnimation}
-      >
-        {children}
-      </div>
-    </CarouselContext.Provider>
-  );
-};
-
-/**
- * 슬라이드 될 item들을 보여주는 컴포넌트
- * Carousel.Root 컴포넌트로 감싸져야 한다.
- *
- * @param items - 슬라이드 될 item들의 배열
- * @param renderItem - 슬라이드 될 item의 렌더링 UI, 파라미터로 item을 받아서 렌더링한다.
- * @param showPreviousItem - 이전 item을 보여줄지 여부 (half | none)
- * @example ~/component/main/MainNewBookList.tsx
- */
-
-type ListProps<T extends { id: number }> = ComponentProps<"ul"> & {
-  items: T[];
-  renderItem: (props: {
-    item: T;
-    key: string;
-    style: CSSProperties;
-  }) => JSX.Element;
-  showPreviousItem?: "half" | "none";
-};
-
-const List = <T extends { id: number }>({
-  items,
-  renderItem,
-  showPreviousItem = "none",
-  className,
-  ...rest
-}: ListProps<T>) => {
-  const {
-    index,
-    startAutoAnimation,
-    pauseAutoAnimation,
-    displayCount,
-    itemSize,
-    direction,
-    isSmoothAnimated,
-  } = useContext(CarouselContext);
-
-  // 슬라이드 될 item들을 복사해서 앞뒤로 붙여준다.
-  // 애니메이션 효과를 위한 앞 마지막 1개와 컨테이너 크기에 맞춰서 복사한 item들을 붙여준다.
-  const displayItems = useMemo(() => {
-    if (items.length === 0) return [];
-    const lastItem = items.slice(-1)[0];
-    const copySize = displayCount / items.length + 1;
-    return [
-      { ...lastItem, key: "last" + lastItem.id },
-      ...items.map(i => ({ ...i, key: `${i.id}` })),
-      ...Array.from({ length: copySize }).flatMap((_, i) =>
-        items.map((_, index) => ({
-          ...items[index % items.length],
-          key: "copy" + i + index, //  key 중복을 피하기 위해 임의로 가공
-        })),
-      ),
-    ];
-  }, [items, displayCount]);
-
-  const prevItemSize = showPreviousItem === "half" ? itemSize / 2 : 0;
-  const translate = direction === "row" ? "translateX" : "translateY";
-
-  return (
-    <ul
-      {...rest}
-      className={`carousel__list ${className}`}
-      style={{
-        // 슬라이더의 이동을 위해 transform을 사용한다.
-        transform: `${translate}(-${itemSize * index + prevItemSize / 2}px)`,
-        flexDirection: direction === "row" ? "row" : "column",
-        transition: isSmoothAnimated ? "transform 0.2s ease-in-out" : "",
-      }}
-      onMouseOver={pauseAutoAnimation}
-      onMouseLeave={startAutoAnimation}
-    >
-      {displayItems.map(item =>
-        renderItem({ item, key: item.key, style: { flexBasis: itemSize } }),
-      )}
-    </ul>
-  );
-};
-
-const Prev = ({ className, ...rest }: ComponentProps<"button">) => {
-  const { onPrev, startAutoAnimation, pauseAutoAnimation } =
-    useContext(CarouselContext);
-
-  return (
-    <button
-      {...rest}
-      onClick={onPrev}
-      className={`carousel__prev ${className}`}
-      onMouseOver={pauseAutoAnimation}
-      onMouseLeave={startAutoAnimation}
-    />
-  );
-};
-
-const Next = ({ className, ...rest }: ComponentProps<"button">) => {
-  const { onNext, startAutoAnimation, pauseAutoAnimation } =
-    useContext(CarouselContext);
-
-  return (
-    <button
-      {...rest}
-      onClick={onNext}
-      className={`carousel__next ${className}`}
-      onMouseOver={pauseAutoAnimation}
-      onMouseLeave={startAutoAnimation}
-    />
-  );
-};
-
-type PaginationProps = {
-  render: (props: {
-    page: number;
-    setPage: (page: number) => void;
-    lastPage?: number;
-  }) => JSX.Element;
-} & ComponentProps<"div">;
-
-const Pagination = ({ render }: PaginationProps) => {
-  const { index, setIndex, length } = useContext(CarouselContext);
-  return render({
-    page: index,
-    setPage: setIndex,
-    lastPage: length - 1,
-  });
-};
-
-export default { Root, Prev, Next, List, Pagination };
+export default Carousel;
+Carousel.Root = CarouselRoot;
+Carousel.Container = CarouselContainer;
+Carousel.List = CarouselList;
+Carousel.Prev = CarouselPrev;
+Carousel.Next = CarouselNext;
+Carousel.Pagination = CarouselPagination;

--- a/src/component/utils/Carousel.tsx
+++ b/src/component/utils/Carousel.tsx
@@ -138,7 +138,7 @@ const Root = ({
 
 type ListProps<T extends { id: number }> = ComponentProps<"ul"> & {
   items: T[];
-  renderItem: (props: ComponentProps<any> & { item: T }) => React.ReactNode;
+  renderItem: (props: { item: T & { key: string } }) => JSX.Element;
   showPreviousItem?: "half" | "none";
 };
 
@@ -193,9 +193,7 @@ const List = <T extends { id: number }>({
       onMouseOver={pauseAutoAnimation}
       onMouseLeave={startAutoAnimation}
     >
-      {displayItems.map(item =>
-        renderItem({ item, key: item.key, style: { flexBasis: itemSize } }),
-      )}
+      {displayItems.map(item => renderItem({ item }))}
     </ul>
   );
 };
@@ -237,6 +235,7 @@ type PaginationProps = {
     lastPage?: number;
   }) => JSX.Element;
 } & ComponentProps<"div">;
+
 const Pagination = ({ render }: PaginationProps) => {
   const { index, setIndex, length } = useContext(CarouselContext);
   return render({

--- a/src/component/utils/CarouselContainer.tsx
+++ b/src/component/utils/CarouselContainer.tsx
@@ -1,0 +1,30 @@
+import { ComponentProps, useContext } from "react";
+import { CarouselContext } from "~/component/utils/Carousel";
+
+/**
+ * 슬라이드 리스트를 감싸는 컴포넌트
+ * item의 크기를 결정하고, 슬라이드 애니메이션을 위한 컨테이너 역할을 한다.
+ * 반드시 Carousel.Root 컴포넌트로 감싸져야 한다.
+ */
+
+const CarouselContainer = ({
+  className,
+  children,
+  ...rest
+}: ComponentProps<"div">) => {
+  const { targetRef, startAutoAnimation, pauseAutoAnimation } =
+    useContext(CarouselContext);
+  return (
+    <div
+      {...rest}
+      className={`carousel__container ${className}`}
+      ref={targetRef}
+      onMouseEnter={pauseAutoAnimation}
+      onMouseLeave={startAutoAnimation}
+    >
+      {children}
+    </div>
+  );
+};
+
+export default CarouselContainer;

--- a/src/component/utils/CarouselList.tsx
+++ b/src/component/utils/CarouselList.tsx
@@ -1,0 +1,84 @@
+import { CSSProperties, ComponentProps, useContext, useMemo } from "react";
+import { CarouselContext } from "~/component/utils/Carousel";
+
+/**
+ * 슬라이드 될 item을 연속으로 늘어놓은 컴포넌트
+ * 슬라이드 효과를 위해 조금씩 이동한다.
+ * 반드시 Carousel.Root 와 Carousel.Container 컴포넌트로 감싸져야 한다.
+ * Root : 필요한 상태 및 제어 설정을 공유받기 위함
+ * Container : 슬라이드 될 item의 크기를 결정하기 위함
+ *
+ * @param items - 슬라이드 될 item들의 배열
+ * @param renderItem - 슬라이드 될 item의 렌더링 UI, 파라미터로 item을 받아서 렌더링한다.
+ * @param showPreviousItem - 이전 item을 보여줄지 여부 (half | none)
+ * @example ~/component/main/MainNewBookList.tsx
+ */
+
+type Props<T extends { id: number }> = ComponentProps<"ul"> & {
+  items: T[];
+  renderItem: (props: {
+    item: T & { key: string };
+    key: string;
+    style: CSSProperties;
+  }) => JSX.Element;
+  showPreviousItem?: "half" | "none";
+};
+
+const CarouselList = <T extends { id: number }>({
+  items,
+  renderItem,
+  showPreviousItem = "none",
+  className,
+  ...rest
+}: Props<T>) => {
+  const {
+    index,
+    startAutoAnimation,
+    pauseAutoAnimation,
+    displayCount,
+    itemSize,
+    direction,
+    isSmoothAnimated,
+  } = useContext(CarouselContext);
+
+  // 슬라이드 될 item들을 복사해서 앞뒤로 붙여준다.
+  // 애니메이션 효과를 위한 앞 마지막 1개와 컨테이너 크기에 맞춰서 복사한 item들을 붙여준다.
+  const displayItems = useMemo(() => {
+    if (items.length === 0) return [];
+    const lastItem = items.slice(-1)[0];
+    const copySize = displayCount / items.length + 1;
+    return [
+      { ...lastItem, key: "last" + lastItem.id },
+      ...items.map(i => ({ ...i, key: `${i.id}` })),
+      ...Array.from({ length: copySize }).flatMap((_, i) =>
+        items.map((_, index) => ({
+          ...items[index % items.length],
+          key: "copy" + i + index, //  key 중복을 피하기 위해 임의로 가공
+        })),
+      ),
+    ];
+  }, [items, displayCount]);
+
+  const prevItemSize = showPreviousItem === "half" ? itemSize / 2 : 0;
+  const translate = direction === "row" ? "translateX" : "translateY";
+
+  return (
+    <ul
+      {...rest}
+      className={`carousel__list ${className}`}
+      style={{
+        transform: `${translate}(-${itemSize * index + prevItemSize / 2}px)`,
+        flexDirection: direction === "row" ? "row" : "column",
+        transition: isSmoothAnimated ? "transform 0.2s ease-in-out" : "",
+      }}
+      onMouseOver={pauseAutoAnimation}
+      onMouseLeave={startAutoAnimation}
+    >
+      {displayItems.map(item =>
+        renderItem({ item, key: item.key, style: { flexBasis: itemSize } }),
+      )}
+    </ul>
+  );
+};
+
+export default CarouselList;

--- a/src/component/utils/CarouselNext.tsx
+++ b/src/component/utils/CarouselNext.tsx
@@ -1,0 +1,19 @@
+import { ComponentProps, useContext } from "react";
+import { CarouselContext } from "~/component/utils/Carousel";
+
+const CarouselNext = ({ className, ...rest }: ComponentProps<"button">) => {
+  const { onNext, startAutoAnimation, pauseAutoAnimation } =
+    useContext(CarouselContext);
+
+  return (
+    <button
+      {...rest}
+      onClick={onNext}
+      className={`carousel__next ${className}`}
+      onMouseOver={pauseAutoAnimation}
+      onMouseLeave={startAutoAnimation}
+    />
+  );
+};
+
+export default CarouselNext;

--- a/src/component/utils/CarouselPagination.tsx
+++ b/src/component/utils/CarouselPagination.tsx
@@ -1,0 +1,26 @@
+import { ComponentProps, useContext } from "react";
+import { CarouselContext } from "~/component/utils/Carousel";
+
+type Props = {
+  render: (props: {
+    page: number;
+    setPage: (page: number) => void;
+    lastPage?: number;
+  }) => JSX.Element;
+} & ComponentProps<"div">;
+
+/**
+ * 임의의 페이지로 이동하기 위한 페이지네이션 컴포넌트
+ * @param render - 페이지네이션 UI를 렌더링하는 함수
+ * 반드시 Carousel.Root 컴포넌트로 감싸져야 한다.
+ */
+const CarouselPagination = ({ render }: Props) => {
+  const { index, setIndex, length } = useContext(CarouselContext);
+  return render({
+    page: index,
+    setPage: setIndex,
+    lastPage: length - 1,
+  });
+};
+
+export default CarouselPagination;

--- a/src/component/utils/CarouselPrev.tsx
+++ b/src/component/utils/CarouselPrev.tsx
@@ -1,0 +1,19 @@
+import { ComponentProps, useContext } from "react";
+import { CarouselContext } from "~/component/utils/Carousel";
+
+const CarouselPrev = ({ className, ...rest }: ComponentProps<"button">) => {
+  const { onPrev, startAutoAnimation, pauseAutoAnimation } =
+    useContext(CarouselContext);
+
+  return (
+    <button
+      {...rest}
+      onClick={onPrev}
+      className={`carousel__prev ${className}`}
+      onMouseOver={pauseAutoAnimation}
+      onMouseLeave={startAutoAnimation}
+    />
+  );
+};
+
+export default CarouselPrev;

--- a/src/component/utils/CarouselRoot.tsx
+++ b/src/component/utils/CarouselRoot.tsx
@@ -1,0 +1,99 @@
+import { useEffect, useState } from "react";
+import { useBound } from "~/hook/useBound";
+import { useInterval } from "~/hook/useInterval";
+import { CarouselContext } from "~/component/utils/Carousel";
+import "~/asset/css/Carousel.css";
+
+type Props = {
+  length: number;
+  itemSize?: number;
+  itemCount?: number;
+  direction?: "row" | "column";
+  delay?: number;
+  isAutoAnimated?: boolean;
+  children: JSX.Element | JSX.Element[];
+} & (
+  | { itemSize: number; itemCount?: never }
+  | { itemCount: number; itemSize?: never }
+);
+
+/**
+ * 슬라이드에 필요한 상태 및 여러 설정을 제어하는 컴포넌트
+ * 다른 Carousel 컴포넌트를 사용하려면 반드시 Root로 감싸야 한다.
+ *
+ * @param length -  슬라이드 될 item의 개수
+ * @param itemSize - 슬라이드 될 item의 크기, margin 포함 실제 크기(px)로 실제 이동하는 거리와 같음
+ * @param itemCount - 슬라이드 될 container에 들어갈 item의 개수, 크기는 자동 조정
+ * @param isAnimated - 슬라이드 애니메이션 여부
+ * itemSize나 itemCount 둘 중 하나만 지정가능, 둘 중 하나는 반드시 지정되어야 함
+ * @param direction - 슬라이드 방향 (row | column)
+ * @param delay - 슬라이드 간의 시간 간격
+ */
+
+const CarouselRoot = ({
+  length,
+  itemSize,
+  itemCount,
+  direction = "row",
+  delay = 2000,
+  isAutoAnimated = true,
+  children,
+}: Props) => {
+  const [slide, setSlide] = useState({ index: 1, isSmoothAnimated: true }); // 슬라이드 움직임 제어
+
+  const { targetRef, boundInfo: bound } = useBound<HTMLDivElement>({
+    hasResizeEvent: true,
+    hasScrollEvent: false,
+  });
+  const containerSize = direction === "row" ? bound.width : bound.height;
+  const displayCount = itemSize
+    ? Math.floor(containerSize / itemSize)
+    : itemCount!;
+
+  const onNext = () => {
+    // 마지막 요소가 첫번째 앞에 추가되었기 때문에 length - 1 대신 length로 이동
+    // 바로 이동하면 동작이 어색함, 애니메이션 효과 false 설정 후 0.01초 뒤에 이동
+    if (slide.index === length) {
+      setSlide({ index: 0, isSmoothAnimated: false });
+      setTimeout(() => setSlide({ index: 1, isSmoothAnimated: true }), 10);
+    } else setSlide({ index: slide.index + 1, isSmoothAnimated: true });
+  };
+
+  const onPrev = () => {
+    if (slide.index === 1) {
+      setSlide({ index: length + 1, isSmoothAnimated: false });
+      setTimeout(() => setSlide({ index: length, isSmoothAnimated: true }), 10);
+    } else setSlide({ index: slide.index - 1, isSmoothAnimated: true });
+  };
+
+  const { startInterval, stopInterval } = useInterval(onNext, delay);
+
+  const startAutoAnimation = () => isAutoAnimated && startInterval();
+  const pauseAutoAnimation = stopInterval;
+
+  useEffect(() => {
+    startAutoAnimation();
+  }, [startAutoAnimation]);
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        index: slide.index,
+        isSmoothAnimated: slide.isSmoothAnimated,
+        onNext,
+        onPrev,
+        setIndex: (index: number) => setSlide(prev => ({ ...prev, index })),
+        startAutoAnimation,
+        pauseAutoAnimation,
+        displayCount,
+        itemSize: itemSize ?? containerSize / itemCount!,
+        length,
+        direction,
+        targetRef,
+      }}
+    >
+      {children}
+    </CarouselContext.Provider>
+  );
+};
+export default CarouselRoot;

--- a/src/component/utils/Tooltip.tsx
+++ b/src/component/utils/Tooltip.tsx
@@ -1,6 +1,6 @@
 import { ReactNode, useState } from "react";
 import { createPortal } from "react-dom";
-import { useBound } from "../../hook/useBound";
+import { useBound } from "~/hook/useBound";
 
 type TooltipProps = {
   className?: string;
@@ -10,7 +10,10 @@ type TooltipProps = {
 
 const Tooltip = ({ children, description, className }: TooltipProps) => {
   const [isDisplayed, setDisplayed] = useState(false);
-  const { boundInfo, targetRef } = useBound<HTMLDivElement>();
+  const { boundInfo, targetRef } = useBound<HTMLDivElement>({
+    hasResizeEvent: true,
+    hasScrollEvent: true,
+  });
 
   const displayTooltip = () => setDisplayed(true);
   const hiddenTooltip = () => setDisplayed(false);

--- a/src/hook/useBound.ts
+++ b/src/hook/useBound.ts
@@ -1,6 +1,14 @@
 import { useEffect, useRef, useState } from "react";
 
-export const useBound = <T extends HTMLElement>() => {
+type Props = {
+  hasResizeEvent?: boolean;
+  hasScrollEvent?: boolean;
+};
+
+export const useBound = <T extends HTMLElement>({
+  hasResizeEvent = true,
+  hasScrollEvent = false,
+}: Props) => {
   const [boundInfo, setBoundInfo] = useState({
     top: 0,
     bottom: 0,
@@ -18,14 +26,13 @@ export const useBound = <T extends HTMLElement>() => {
 
   useEffect(() => {
     getBound();
-    window.addEventListener("resize", getBound);
-    window.addEventListener("scroll", getBound);
+    if (hasResizeEvent) window.addEventListener("resize", getBound);
+    if (hasScrollEvent) window.addEventListener("scroll", getBound);
     return () => {
-      window.removeEventListener("scroll", getBound);
-      window.removeEventListener("resize", getBound);
+      if (hasScrollEvent) window.removeEventListener("scroll", getBound);
+      if (hasResizeEvent) window.removeEventListener("resize", getBound);
     };
   }, []);
 
   return { targetRef, boundInfo };
 };
-

--- a/src/hook/useInterval.ts
+++ b/src/hook/useInterval.ts
@@ -25,7 +25,6 @@ export const useInterval = (callback: () => void, delay: number) => {
   };
 
   useEffect(() => {
-    startInterval();
     return stopInterval;
   }, [callback, delay]);
 

--- a/src/hook/useInterval.ts
+++ b/src/hook/useInterval.ts
@@ -1,0 +1,33 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * useInterval SetInterval을 사용하기 위한 Hook
+ *
+ * @param callback 간격마다 실행할 함수
+ * @param delay 실행 간격 (ms)
+ * @returns startInterval: setInterval 재시작을 위한 함수, stopInterval: setInterval 종료 함수
+ * @example const { startInterval, stopInterval } = useInterval(() => { console.log("interval") }, 1000);
+ */
+
+export const useInterval = (callback: () => void, delay: number) => {
+  const intervalId = useRef<NodeJS.Timeout | null>(null);
+
+  const stopInterval = () => {
+    if (intervalId.current) {
+      clearInterval(intervalId.current);
+      intervalId.current = null;
+    }
+  };
+
+  const startInterval = () => {
+    stopInterval();
+    intervalId.current = setInterval(callback, delay);
+  };
+
+  useEffect(() => {
+    startInterval();
+    return stopInterval;
+  }, [callback, delay]);
+
+  return { startInterval, stopInterval };
+};

--- a/src/hook/useResponsiveWidth.ts
+++ b/src/hook/useResponsiveWidth.ts
@@ -1,0 +1,29 @@
+import { useEffect, useState } from "react";
+
+type Props = {
+  pcWidth: number;
+  tabletWidth?: number;
+  mobileWidth: number;
+};
+
+export const useResponsiveWidth = ({
+  pcWidth,
+  tabletWidth,
+  mobileWidth,
+}: Props) => {
+  const [width, setSize] = useState(pcWidth);
+
+  const resize = () => {
+    if (window.innerWidth <= 767) setSize(tabletWidth ?? mobileWidth);
+    else if (window.innerWidth <= 600) setSize(mobileWidth);
+    else setSize(pcWidth);
+  };
+
+  useEffect(() => {
+    resize();
+    window.addEventListener("resize", resize);
+    return () => window.removeEventListener("resize", resize);
+  }, []);
+
+  return { width };
+};


### PR DESCRIPTION
# 개요
메인페이지 신규도서 부분 코드에서 carousel UI와 관련된 부분을 추출했습니다.
이 Carousel을 활용해서 인기 검색어와 추천도서 UI를 구현할 예정입니다

- fixes #559


### Preview
| 이미지 | 설명|
|---|---|
|![Aug-29-2023 00-04-28](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/6772806b-82d1-4258-8f90-34bf03629365)|버튼으로 조작가능, 처음과 끝의 전환이 자연스럽게 넘어감|
|![Aug-29-2023 00-06-35](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/10e317ce-f8fc-472b-b3eb-ee64f4ba64bf)|hover 시 애니메이션 멈춤, 떠나면 재시작|



### 참고사항
- story를 짜서 활용방법도 같이 다루면 좋겠지만 경진대회 일정상 스토리까지는 추가하지 못했습니다
- 관련된 내용을 최대한 주석으로 담았습니다 9월 중순쯤에 스토리에 반영하겠습니다
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
