### PR TITLE
fix: useApi 임시 활용방법 추가

### DIFF
--- a/src/hook/useApi.ts
+++ b/src/hook/useApi.ts
@@ -4,12 +4,12 @@ import axiosPromise from "../util/axios";
 
 type Method = "get" | "post" | "put" | "patch" | "delete";
 
-export const useApi = (method: Method, url: string, data?: unknown) => {
+export const useApi = (method?: Method, url?: string, data?: unknown) => {
   const { addErrorDialog } = useNewDialog();
 
   const request = useCallback(
     (resolve: (response: any) => void, reject?: (error: any) => void) => {
-      axiosPromise(method, url, data)
+      axiosPromise(method ?? "GET", url ?? "/", data)
         ?.then(response => {
           resolve(response);
         })
@@ -22,5 +22,24 @@ export const useApi = (method: Method, url: string, data?: unknown) => {
     [method, url, data],
   );
 
-  return { request };
+  const requestWithUrl = (
+    method: Method,
+    url: string,
+    options?: {
+      data?: unknown;
+      onSuccess?: (response: any) => void;
+      onError?: (error: any) => void;
+    },
+  ) => {
+    axiosPromise(method, url, options?.data)
+      ?.then(response => {
+        if (options?.onSuccess) options.onSuccess(response);
+      })
+      ?.catch(error => {
+        if (options?.onError) options.onError(error);
+        else addErrorDialog(error);
+      });
+  };
+
+  return { request, requestWithUrl };
 };


### PR DESCRIPTION
# 개요
useApi 활용방식 추가 

### 목적
- ts-rest 도입이 완료될때까지 useApi를 활용해야 합니다
- 현재 useApi의 request는 url과 data가 훅 호출 시점에 결정되어 랜더링이 바뀌기 전의 값이 고정됩니다
- 실제 api 호출 시점에 url과 data를 결정할 수 있도록 하는 requestWithUrl 함수를 추가했습니다 

- fixes #563

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
