### PR TITLE
fix: 최근 검색어 최대 10개로 제한

### DIFF
--- a/src/component/utils/BookSearchBar.tsx
+++ b/src/component/utils/BookSearchBar.tsx
@@ -5,6 +5,7 @@ import SearchBar from "~/component/utils/SearchBar";
 import BookSearchPreview from "~/component/utils/BookSearchPreview";
 import BookSearchRecentKeyword from "~/component/utils/BookSearchRecentKeywords";
 
+const RECENT_LIMIT = 10;
 const BookSearchBar = () => {
   const [isOpened, setIsOpened] = useState(false);
   const { books, totalCount, keyword, setKeyword, isLoading } =
@@ -20,7 +21,10 @@ const BookSearchBar = () => {
     const recentKeywords = JSON.parse(storageSaved);
     if (!recentKeywords.includes(searchWord)) {
       recentKeywords.unshift(searchWord);
-      localStorage.setItem("recent", JSON.stringify(recentKeywords));
+      localStorage.setItem(
+        "recent",
+        JSON.stringify(recentKeywords.slice(0, RECENT_LIMIT)),
+      );
     }
     navigate(`/search?search=${encodeURIComponent(searchWord)}`);
     e.currentTarget.input.blur();


### PR DESCRIPTION
# 개요
최대 10개로 제한하기 위해 검색어 추가시 slice 해서 저장합니다

- fixes #571

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
