### PR TITLE
fix: 도서 검색 리다이렉트시 URI 인코딩 추가

### DIFF
--- a/src/component/utils/BookSearchPreview.tsx
+++ b/src/component/utils/BookSearchPreview.tsx
@@ -51,7 +51,7 @@ const BookSearchPreview = ({
       </Paginations.Root>
       <Link
         className="search-preview__more"
-        to={`/search?search=${encodeURI(keyword)}`}
+        to={`/search?search=${encodeURIComponent(keyword)}`}
       >
         {!isLoading && totalCount ? (
           <EmphasisInString

--- a/src/component/utils/SearchRankingList.tsx
+++ b/src/component/utils/SearchRankingList.tsx
@@ -1,4 +1,4 @@
-import { ComponentProps, useState } from "react";
+import { ComponentProps, useEffect, useState } from "react";
 import { type SearchKeyword } from "~/type/SearchKeyword";
 import Carousel from "./Carousel";
 import SearchRankingItem from "./SearchRankingItem";
@@ -33,7 +33,9 @@ const SearchRankingList = ({ list }: Props) => {
             <Image src={ToggleDownArrow} alt="인기검색어 닫기" />
           </p>
           {list.map(item => (
-            <Link to={`search?search=${item.searchKeyword}`}>
+            <Link
+              to={`search?search=${encodeURIComponent(item.searchKeyword)}`}
+            >
               <SearchRankingItem key={item.id} item={item} height={HEIGHT} />
             </Link>
           ))}


### PR DESCRIPTION
# 개요
인기검색어에서 클릭시 검색어가 제대로 보이지 않는 문제를 해결했습니다. 

- fixes #574 

### 변경사항
입력어포함 URL로 이동할때 특수문자를 위한 인코딩추가


### preview
![Sep-07-2023 12-04-44](https://github.com/jiphyeonjeon-42/frontend/assets/74622889/18ec7145-496e-4693-a39a-fa6d93efccdc)
<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
