### PR TITLE
fix: 검색창 입력시 기본 새로고침 해제

### DIFF
--- a/src/component/utils/SearchBar.tsx
+++ b/src/component/utils/SearchBar.tsx
@@ -11,11 +11,19 @@ export type Props = ComponentProps<"form"> & {
 const SearchBar = ({
   width = "banner",
   className = "",
+  onSubmit,
   children,
   ...rest
 }: Props) => {
   return (
-    <form {...rest} className={`search-bar__wrapper ${width} ${className}`}>
+    <form
+      {...rest}
+      className={`search-bar__wrapper ${width} ${className}`}
+      onSubmit={e => {
+        e.preventDefault();
+        onSubmit && onSubmit(e);
+      }}
+    >
       {children}
     </form>
   );


### PR DESCRIPTION
# 개요
form 태그의 onSubmit 기본동작인 새로고침 해제

- 검색창 개선시 기본동작 해제 코드가 사라졌습니다
(관련PR : #551)


- 일반적으로 새로고침을 기대하지 않기 때문에 기본동작은 해제하고 
필요할 때만 새로고침 코드를 추가할 수 있도록 수정했습니다. 


- fixes #583

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
