### PR TITLE
fix: mypage의 userInfo요청 useGetUsersSearchId -> useGetUsersMe로 변경

### DIFF
--- a/src/api/users/useGetUsersMe.ts
+++ b/src/api/users/useGetUsersMe.ts
@@ -1,0 +1,18 @@
+import { useEffect, useState } from "react";
+import { useApi } from "../../hook/useApi";
+import { User } from "../../type";
+
+export const useGetUsersMe = () => {
+  const [userInfo, setUserInfo] = useState<User>();
+
+  const { request } = useApi("get", "users/me");
+
+  const refineResponse = (response: any) => {
+    const user = response.data;
+    setUserInfo(user);
+  };
+
+  useEffect(() => request(refineResponse), []);
+
+  return { userInfo };
+};

--- a/src/component/mypage/MyRentInfo/MyRent.tsx
+++ b/src/component/mypage/MyRentInfo/MyRent.tsx
@@ -1,4 +1,4 @@
-import { useGetUsersSearchId } from "~/api/users/useGetUsersSearchId";
+import { useGetUsersMe } from "~/api/users/useGetUsersMe";
 import RentHistory from "./RentHistory";
 import RentedOrReservedBooks from "./RentedOrReservedBooks";
 import InquireBoxTitle from "~/component/utils/InquireBoxTitle";
@@ -8,7 +8,7 @@ import { userIdAtom } from "~/atom/userAtom"
 
 const MyRent = () => {
   const userId = useRecoilValue(userIdAtom);
-  const { userInfo } = useGetUsersSearchId({ userId });
+  const { userInfo } = useGetUsersMe();
 
   return (
     <>

--- a/src/component/mypage/MyReservation.tsx
+++ b/src/component/mypage/MyReservation.tsx
@@ -1,4 +1,4 @@
-import { useGetUsersSearchId } from "~/api/users/useGetUsersSearchId";
+import { useGetUsersMe } from "~/api/users/useGetUsersMe";
 import RentedOrReservedBooks from "./MyRentInfo/RentedOrReservedBooks";
 import InquireBoxTitle from "~/component/utils/InquireBoxTitle";
 import Reserve from "~/asset/img/list-check-solid.svg";
@@ -7,7 +7,7 @@ import { userIdAtom } from "~/atom/userAtom"
 
 const MyReservation = () => {
   const userId = useRecoilValue(userIdAtom);
-  const { userInfo } = useGetUsersSearchId({ userId });
+  const { userInfo } = useGetUsersMe();
 
   return (
     <>

--- a/src/component/mypage/Mypage.tsx
+++ b/src/component/mypage/Mypage.tsx
@@ -3,7 +3,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import { myPageTabList } from "../../constant/tablist";
 import { useTabFocus } from "../../hook/useTabFocus";
 import { useNewDialog } from "../../hook/useNewDialog";
-import { useGetUsersSearchId } from "../../api/users/useGetUsersSearchId";
+import { useGetUsersMe } from "../../api/users/useGetUsersMe";
 import { lendingRestriction } from "../../util/date";
 import MyRent from "./MyRentInfo/MyRent";
 import MyReservation from "./MyReservation";
@@ -26,7 +26,7 @@ const Mypage = () => {
     myReview: <MyReview />,
   };
   const userId = useRecoilValue(userIdAtom);
-  const { userInfo } = useGetUsersSearchId({ userId });
+  const { userInfo } = useGetUsersMe();
   const [deviceMode, setDeviceMode] = useState("desktop");
 
   const convertRoleToStr = (roleInt: number) => {


### PR DESCRIPTION
# 개요

- 마이페이지에서 정보요청할 때 이전 요청(users/search/{id})은 사서 권한이 아니면 정보를 주지 않았음.
- users/me 요청을 통해 마이페이지의 정보를 받아오도록 get 요청 변경

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
