### PR TITLE
fix: 바코드 버튼 글씨 대신 이미지로 변경

### DIFF
--- a/src/component/utils/ManagementSearchBar.tsx
+++ b/src/component/utils/ManagementSearchBar.tsx
@@ -6,6 +6,8 @@ import {
   useState,
 } from "react";
 import SearchBar from "~/component/utils/SearchBar";
+import Image from "./Image";
+import BarcodeIcon from "~/asset/img/barcode.svg";
 
 type Props = {
   width: "banner" | "center" | "short" | "long";
@@ -57,7 +59,7 @@ const ManagementSearchBar = ({
           className="search-bar__button barcode"
           onClick={onClickBarcodeButton}
         >
-          바코드
+          <Image src={BarcodeIcon} alt="바코드" />
         </button>
       ) : null}
       <SearchBar.Button />


### PR DESCRIPTION
# 개요
바코드 이미지로 변경했습니다
SearchBar => ManagementSearchBar로 변경하는 과정에서 글씨로 변경되었던 점을 다시 복구했습니다

- fixes #596

### preview

|변경전| <img width="1224" alt="스크린샷 2023-11-29 오후 2 30 57" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/5d280d0b-94d4-4775-a573-1201507ed6e0">|
|---|---|
|변경후|<img width="1224" alt="스크린샷 2023-11-29 오후 2 30 38" src="https://github.com/jiphyeonjeon-42/frontend/assets/74622889/cdc9acb0-92a7-4c46-9b55-95ae5b32d61f">|

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
