### PR TITLE
fix: 도서 등록 폼에 카테고리 선택 코드 수정

### DIFF
--- a/src/component/addbook/AddBookRegisterBookWithUsersExtraInput.tsx
+++ b/src/component/addbook/AddBookRegisterBookWithUsersExtraInput.tsx
@@ -16,39 +16,59 @@ type Props = {
   bookInfo: Omit<BookInfo, "id">;
 };
 
-const RegisterBookWithUsersExtraInput = ({ bookInfo }: Props) => {
-  const [isDevBook, setIsDevBook] = useState<"" | "true" | "false">("");
-  const [categoryId, setCategoryId] = useState("");
-  const donator = useRef<HTMLInputElement>(null);
-  const isReadyToPost = categoryId && bookInfo.title && bookInfo.author;
+type IsDevBook = "" | "dev" | "non-dev";
 
-  useEffect(() => {
-    setIsDevBook("");
-    setCategoryId("");
-  }, [bookInfo]);
+const categoryOptions = {
+  "": [],
+  "dev": category.filter(item => item.isDev),
+  "non-dev": category.filter(item => !item.isDev),
+};
+
+const CategoryOptions = ({ options }: { options: { id: string; name: string }[] }) => (
+  <>
+    {options.map((element) => (
+      <option value={element.id} key={element.id}>
+        {element.name}
+      </option>
+    ))}
+  </>
+);
+
+const RegisterBookWithUsersExtraInput = ({ bookInfo }: Props) => {
+  const [isDevBook, setIsDevBook] = useState<IsDevBook>(() => "");
+  const [categoryId, setCategoryId] = useState(() => "");
+  const [donator, setDonator] = useState(() => "");
+  
+  const isReadyToPost = bookInfo.title && bookInfo.author && categoryId && donator;
 
   const { message, registerBook } = usePostBooksCreate();
+  
+  const handleSelectIsDevBook: ChangeEventHandler<HTMLSelectElement> = e =>
+    setIsDevBook(prev => prev === e.target.value ? prev : e.target.value as IsDevBook);
+
+  const handleSelectCategoryId: ChangeEventHandler<HTMLSelectElement> = e =>
+    setCategoryId(prev => prev === e.target.value ? prev : e.target.value);
+
+  const handleChangeDonator = (e: React.ChangeEvent<HTMLInputElement>) => setDonator(e.target.value);
+
+  <CategoryOptions options={categoryOptions[isDevBook] || []} />
 
   const onSubmit: FormEventHandler = e => {
     e.preventDefault();
-    registerBook({
-      ...bookInfo,
-      categoryId: +categoryId,
-      donator: donator.current?.value || "",
-    });
-  };
-
-  const setDev: ChangeEventHandler<HTMLSelectElement> = e => {
-    const { value } = e.currentTarget;
-    if (value === "true") {
-      setCategoryId("");
-      setIsDevBook(value);
-    } else if (value === "false") {
-      const id = 중앙도서관도서분류.find(i => i.id === bookInfo.category);
-      if (id) setCategoryId(id?.categoryId);
-      setIsDevBook("false");
+    if (isReadyToPost) {
+      registerBook({
+        ...bookInfo,
+        categoryId: +categoryId,
+        donator
+      });
+    } else {
+      alert("모든 정보를 입력해주세요");
     }
   };
+
+  useEffect(() => {
+    setCategoryId(() => ""); // categoryId 초기화
+  }, [isDevBook]);
 
   return (
     <form className="add-book__create-form" onSubmit={onSubmit}>
@@ -59,12 +79,12 @@ const RegisterBookWithUsersExtraInput = ({ bookInfo }: Props) => {
           className="add-book__isDev-select"
           name="isDevCategory"
           id="isDevCategory"
-          value={`${isDevBook}`}
-          onChange={setDev}
+          value={isDevBook}
+          onChange={handleSelectIsDevBook}
         >
           <option value="">대분류를 선택해주세요</option>
-          <option value="true">개발</option>
-          <option value="false">비개발</option>
+          <option value="dev">개발</option>
+          <option value="non-dev">비개발</option>
         </select>
         <select
           required
@@ -72,24 +92,24 @@ const RegisterBookWithUsersExtraInput = ({ bookInfo }: Props) => {
           name="category"
           id="category-select"
           value={categoryId}
-          onChange={e => setCategoryId(e.currentTarget.value)}
+          onChange={handleSelectCategoryId}
         >
           <option value="">카테고리를 선택하세요</option>
-          {category
-            ?.filter(items => `${items.isDev}` === isDevBook)
-            ?.map(element => {
-              return (
-                <option value={element.id} key={element.id}>
-                  {element.name}
-                </option>
-              );
-            })}
+          <CategoryOptions options={categoryOptions[isDevBook] ?? []} />
         </select>
       </div>
       <p className="color-red">기부자 정보</p>
-      <input type="text" id="donator" ref={donator} />
+      <input
+        required
+        type="text"
+        id="donator"
+        name="donator"
+        value={donator}
+        onChange={handleChangeDonator}
+        placeholder="기부자 이름을 입력해주세요"
+      />
       <p className="add-book__create-form__errror-Message">{message}</p>
-      <button type="submit" className={isReadyToPost && "red"}>
+      <button type="submit" className={isReadyToPost ? "red" : ""}>
         등록하기
       </button>
     </form>

--- a/src/component/addbook/AddBookRegisterBookWithUsersExtraInput.tsx
+++ b/src/component/addbook/AddBookRegisterBookWithUsersExtraInput.tsx
@@ -51,8 +51,6 @@ const RegisterBookWithUsersExtraInput = ({ bookInfo }: Props) => {
 
   const handleChangeDonator = (e: React.ChangeEvent<HTMLInputElement>) => setDonator(e.target.value);
 
-  <CategoryOptions options={categoryOptions[isDevBook] || []} />
-
   const onSubmit: FormEventHandler = e => {
     e.preventDefault();
     if (isReadyToPost) {


### PR DESCRIPTION
제대로 동작하지 않은 오류 수정
- Select에서 선택시 useSatete의 값들이 올바르게 설정되도록 수정
- 개발/비개발 영역 새로운 값 선택시, 카테고리 아이디는 ""로 초기화
- 중앙도서관분류를 사용하는 부분은 무엇이 의도인지 몰라 우선 삭제 (추후 체크후 추가 커밋 필요할수도)

오류 수정 외
- donator 받는 input 영역도 useState로 수정
- donator도 required 옵션 부여 && isReadyToPost에 반영

# 개요
도서 등록 select 태그를 사용한 드롭다운 버튼이 제대로 동작하지 않는 오류를 수정했습니다.

- fixes #606