### PR TITLE
fix: 모바일화면에서 화면이 밀리는 현상 및 태그기능 버그 수정

### DIFF
--- a/src/asset/css/Tags.css
+++ b/src/asset/css/Tags.css
@@ -120,7 +120,7 @@
   background-color: rgba(00, 00, 00, 0);
   z-index: 1;
   top: 50%;
-  left: 50%;
+  left: 0;
 }
 
 .button_tag-image-button-disabled {

--- a/src/asset/css/Tags.css
+++ b/src/asset/css/Tags.css
@@ -13,7 +13,7 @@
   line-height: 3rem;
   font-size: 1.5rem;
   font-weight: bold;
-  padding: 1rem 2rem 1rem 2rem;
+  padding: 1rem 2rem 1rem 1rem;
   text-align: center;
   margin: 1rem;
   border-radius: 10px;
@@ -43,12 +43,18 @@
 }
 
 .button_tag-create-box {
-  position: flex;
   line-height: 4rem;
   font-size: large;
   margin: 1rem;
   background-color: rgba(95, 63, 54, 1);
   color: rgba(255, 255, 255, 0.9);
+  width: 100%;
+}
+
+@media screen and (min-width: 767px) {
+  .button_tag-create-box {
+    width: 50%;
+  }
 }
 
 .button_tag-create-box::placeholder {
@@ -66,7 +72,6 @@
   height: 100%;
   min-height: 12rem;
   overflow: hidden;
-  padding: 1.5rem 1rem;
   margin: 6rem 0rem 0rem 0rem;
   background-color: rgb(232, 232, 232, 0.9);
   border-radius: 1rem;
@@ -83,7 +88,6 @@
   height: 100%;
   min-height: 12rem;
   overflow: hidden;
-  padding: 1.5rem 1rem;
   margin: -1.3rem 0rem 10rem 0rem;
   background-color: rgb(232, 232, 232, 0.9);
   border-radius: 1rem;
@@ -117,6 +121,13 @@
   z-index: 1;
   top: 50%;
   left: 50%;
+}
+
+.button_tag-image-button-disabled {
+  display: flex;
+  cursor: not-allowed;
+  opacity: 0.4;
+  pointer-events: none;
 }
 
 @keyframes rotateImage {

--- a/src/asset/css/Tags.css
+++ b/src/asset/css/Tags.css
@@ -130,6 +130,10 @@
   pointer-events: none;
 }
 
+.tooltip_cursor-message {
+  cursor: "help";
+}
+
 @keyframes rotateImage {
   0% {
     transform: rotate(0deg);

--- a/src/component/book/tag/TagList.tsx
+++ b/src/component/book/tag/TagList.tsx
@@ -7,6 +7,8 @@ import Tag from "./Tag";
 import TagModal from "./TagModal";
 import plusicon from "../../../asset/img/tag_plus.svg";
 import Tooltip from "../../utils/Tooltip";
+import { useRecoilValue } from "recoil";
+import { userAtom } from "../../../atom/userAtom";
 
 type TagListProps = {
   tagData: TagType[];
@@ -14,6 +16,7 @@ type TagListProps = {
 };
 
 const TagList = ({ tagData, setTagData }: TagListProps) => {
+  const isLogin = useRecoilValue(userAtom);
   const inputRef = useRef<HTMLInputElement>(null);
   const location = useLocation();
   const bookId = location.pathname.split("/")[2];
@@ -167,7 +170,10 @@ const TagList = ({ tagData, setTagData }: TagListProps) => {
             onKeyUp={handleKeyPress}
           />
 
-          <Tooltip description="태그 등록">
+          <Tooltip
+            className={`${isLogin} ? "" : button_tag-image-button-disabled`}
+            description="태그 등록"
+          >
             <img
               className="button_tag-image-button"
               src={plusicon}

--- a/src/component/book/tag/TagList.tsx
+++ b/src/component/book/tag/TagList.tsx
@@ -8,6 +8,7 @@ import plusicon from "../../../asset/img/tag_plus.svg";
 import Tooltip from "../../utils/Tooltip";
 import { useRecoilValue } from "recoil";
 import { userAtom } from "../../../atom/userAtom";
+import { AxiosError, AxiosResponse } from "axios";
 
 type TagListProps = {
   tagData: TagType[];
@@ -37,18 +38,15 @@ const TagList = ({ tagData, setTagData }: TagListProps) => {
     }
   }, [errorCode]);
 
-  const onSuccess = (response: any) => {
-    if (response.data === undefined) {
-      setErrorCode(42);
-      errorCodeRef.current = 42;
-      return;
-    }
+  const onSuccess = (response: AxiosResponse) => {
     const resTagdata: TagType = response.data;
     setTagData(prev => [...prev, resTagdata]);
     resetCreateContent();
   };
 
-  const onError = (error: any) => {
+  const onError = (error: AxiosError) => {
+    // 400에러 처리 로직이 있지만 콘솔에 찍히는 것을 막기 위해 추가
+    console.clear();
     setErrorCode(parseInt(error?.response?.data?.errorCode, 10));
     errorActive();
   };

--- a/src/component/book/tag/TagList.tsx
+++ b/src/component/book/tag/TagList.tsx
@@ -45,8 +45,6 @@ const TagList = ({ tagData, setTagData }: TagListProps) => {
   };
 
   const onError = (error: AxiosError) => {
-    // 400에러 처리 로직이 있지만 콘솔에 찍히는 것을 막기 위해 추가
-    console.clear();
     setErrorCode(parseInt(error?.response?.data?.errorCode, 10));
     errorActive();
   };

--- a/src/component/book/tag/TagList.tsx
+++ b/src/component/book/tag/TagList.tsx
@@ -16,7 +16,7 @@ type TagListProps = {
 };
 
 const TagList = ({ tagData, setTagData }: TagListProps) => {
-  const isLogin = useRecoilValue(userAtom);
+  const { isLogin } = useRecoilValue(userAtom);
   const inputRef = useRef<HTMLInputElement>(null);
   const location = useLocation();
   const bookId = location.pathname.split("/")[2];
@@ -82,6 +82,9 @@ const TagList = ({ tagData, setTagData }: TagListProps) => {
       const now = Date.now();
       if (now - lastPress < 300) return;
       setLastPress(now);
+      if (!isLogin) {
+        setErrorCode(102); //이거 하고 아래 errorCode가 바로 안바뀌니 useEffect, useRef 사용 고려...졸리다..
+      }
       if (createTag === "") {
         setErrorCode(1);
       } else if (createTag.length > 42) {
@@ -171,7 +174,7 @@ const TagList = ({ tagData, setTagData }: TagListProps) => {
           />
 
           <Tooltip
-            className={`${isLogin} ? "" : button_tag-image-button-disabled`}
+            className={`${isLogin ? "" : "button_tag-image-button-disabled"}`}
             description="태그 등록"
           >
             <img

--- a/src/component/utils/Tooltip.tsx
+++ b/src/component/utils/Tooltip.tsx
@@ -24,8 +24,7 @@ const Tooltip = ({ children, description, className }: TooltipProps) => {
       ref={targetRef}
       onMouseOver={displayTooltip}
       onMouseOut={hiddenTooltip}
-      style={{ cursor: "help" }}
-      className={className}
+      className={`tooltip_cursor-message ${className}`}
     >
       {children}
       {isDisplayed && portal

--- a/src/util/axios.ts
+++ b/src/util/axios.ts
@@ -18,5 +18,8 @@ export default axiosPromise;
 
 api.interceptors.response.use(
   response => response,
-  error => Sentry.captureException(error),
+  error => {
+    Sentry.captureException(error);
+    throw error;
+  },
 );


### PR DESCRIPTION
# 개요
아래의 버그를 수정했습니다.
1. 모바일에서 화면 밀리는 버그
2. 태그 안의 텍스트가 잘리는 버그
3. 2번을 진행하면서 태그의 특정 입력값에 따른 에러핸들링을 추가했습니다.
    a. 비로그인 시, 태그 제출이 불가능하도록 버튼을 비활성화하고 에러코드를 활성화시켰습니다.
    b. 빈 값, 'ㄴ' 같은 자음, 중복된 태그일 때 에러핸들링이 되어있지만 onError로 가지 않고 onSuccess로 가는 것을 확인하여 onSuccess에서 추가 처리했습니다.
    c. 기존 코드에 setter 함수로 에러코드를 설정하고 바로 태그 등록하는 로직이 있었고, setter 함수는 async가 내부에 있기때문에 에러코드가 바로 바뀌지 않음. 그래서 useEffect로 에러코드 변경에 따른 에러활성화 로직을 추가하고 errorCodeRef(useRef 사용) 변수로 에러를 즉시 감지할 수 있도록 추가했습니다.
    d. 중복된 태그, 'ㄴ' 같은 자음 입력값은 프론트에서 처리된 게 아니라 백엔드에서 처리됐는데 onError로 오지 않고 onSuccess로 받고 있기때문에 (정확한 원인 모름) 콘솔에서 400에러가 뜨고 있음 => 알수없는 에러로 모두 처리

=> d 에 대한 에러 원인 해결을 [하단](#-400-에러를-못잡는-현상을-고친-방법)에 적어놨습니다.

## 참고 이슈
#629 

## 스크린샷
![비로그인상태](https://github.com/user-attachments/assets/e62e7a05-36ad-48f0-b291-308acac76c9c)
![로그인상태](https://github.com/user-attachments/assets/97c406f1-4197-458a-ba1d-1f9c78f00a3d)

## 400 에러를 못잡는 현상을 고친 방법
이번 주 프론트 미팅을 진행하면서 @YeonSeong-Lee 님이 도와주셨습니다 🥺

**변경 전**
```typescript
// axios.ts
api.interceptors.response.use(
  response => response,
  error => Sentry.captureException(error),
);
``` 

```typescript
// useApi.ts
  const request = useCallback(
    (resolve: (response: any) => void, reject?: (error: any) => void) => {
      axiosPromise(method ?? "GET", url ?? "/", data)
        ?.then(response => {
          resolve(response);
        })
        ?.catch(error => {
          // 직접 정의한 reject함수가 없으면 기본적인 에러 알림 다이얼로그 호출
          if (reject) reject(error);
          else addErrorDialog(error);
        });
    },
    [method, url, data],
  );
```
axios에서 에러가 제대로 throw 되지 않는 현상이 있었고 catch 블록에 에러가 전달되지 않았습니다. 결과적으로 모든 API 응답이 성공적으로 처리된 것처럼 보였습니다.
Sentry.captureException(error)을 사용하여 에러를 기록하지만, 에러를 throw하지 않아 Axios가 에러를 catch 블록으로 전달하지 않았고, then으로 처리가 되었습니다. 

**변경 후** 
```typescript
// axios.ts
api.interceptors.response.use(
  response => response,
  error => {
    Sentry.captureException(error);
    throw error;
  },
);
```
수정된 코드에서는 throw error를 추가하여 에러가 발생하면 다시 던져서 원래 요청을 처리한 catch 블록으로 전달되도록 했습니다.