### PR TITLE
fix: 책 상세 진입때 스크롤 관련 버그

### DIFF
--- a/src/api/books/useGetBooksInfoSearchUrl.ts
+++ b/src/api/books/useGetBooksInfoSearchUrl.ts
@@ -19,6 +19,7 @@ export const useGetBooksInfoSearchUrl = () => {
   });
   const [query, page, sort, category] =
     useParseUrlQueryString(searchUrlQueryKeys);
+  const [isFetched, setIsFetched] = useState(false);
 
   const { request } = useApi("get", "books/info/search", {
     query,
@@ -59,6 +60,7 @@ export const useGetBooksInfoSearchUrl = () => {
     );
     const { totalPages } = response.data.meta;
     const categoryIndex = categories.findIndex(i => i.name === category);
+    setIsFetched(true);
     setSearchResult({
       bookList: book,
       categoryList: categories,
@@ -73,5 +75,6 @@ export const useGetBooksInfoSearchUrl = () => {
 
   return {
     ...searchResult,
+    isFetched,
   };
 };

--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -28,8 +28,16 @@ const compareCallsign = (a: Book, b: Book) => {
 const BookDetail = () => {
   const id = useParams().id || "";
   const myRef = useRef<HTMLDivElement>(null);
+  const recentScrollPosition = useRef(0);
   const location = useLocation();
-  useEffect(() => myRef.current?.scrollIntoView(), [myRef.current]);
+
+  useEffect(() => {
+    recentScrollPosition.current = window.scrollY;
+    myRef.current?.scrollIntoView();
+    return () => {
+      window.scrollTo(0, recentScrollPosition.current);
+    };
+  }, [myRef.current]);
   const { bookDetailInfo } = useGetBooksInfoId({ id });
 
   if (!bookDetailInfo) {

--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -29,7 +29,7 @@ const BookDetail = () => {
   const id = useParams().id || "";
   const myRef = useRef<HTMLDivElement>(null);
   const location = useLocation();
-  useEffect(() => myRef.current?.scrollIntoView(), []);
+  useEffect(() => myRef.current?.scrollIntoView(), [myRef.current]);
   const { bookDetailInfo } = useGetBooksInfoId({ id });
 
   if (!bookDetailInfo) {

--- a/src/component/book/BookDetail.tsx
+++ b/src/component/book/BookDetail.tsx
@@ -10,7 +10,6 @@ import Like from "~/component/book/like/Like";
 import TagWrapper from "~/component/book/tag/TagWrapper";
 import "~/asset/css/BookDetail.css";
 import { Book } from "~/type";
-import { Helmet } from "react-helmet-async";
 import HelmetComponent from "../utils/HelmetComponent";
 
 const callsignToNumbers = (callSign: string) =>
@@ -32,7 +31,6 @@ const BookDetail = () => {
   const location = useLocation();
   useEffect(() => myRef.current?.scrollIntoView(), []);
   const { bookDetailInfo } = useGetBooksInfoId({ id });
-
 
   if (!bookDetailInfo) {
     return (
@@ -59,7 +57,11 @@ const BookDetail = () => {
 
   return (
     <main>
-      <HelmetComponent title={bookDetailInfo.title} description={ `집현전의 소중한 자산 "${bookDetailInfo.title}" 입니다.`}  img={bookDetailInfo.image} />
+      <HelmetComponent
+        title={bookDetailInfo.title}
+        description={`집현전의 소중한 자산 "${bookDetailInfo.title}" 입니다.`}
+        img={bookDetailInfo.image}
+      />
       <Banner
         img="bookdetail"
         titleKo="도서 상세 및 예약"

--- a/src/component/search/Search.tsx
+++ b/src/component/search/Search.tsx
@@ -12,7 +12,7 @@ import SearchSection from "./SearchSection";
 
 const Search = () => {
   const myRef = useRef<HTMLDivElement>(null);
-  const { bookList, categoryList, lastPage, categoryIndex } =
+  const { bookList, categoryList, lastPage, categoryIndex, isFetched } =
     useGetBooksInfoSearchUrl();
   const [urlSearchParams, setUrlSearchParams] = useSearchParams();
   const [query, page, sort] = useParseUrlQueryString(searchUrlQueryKeys);
@@ -63,6 +63,7 @@ const Search = () => {
         setPage={setPage}
         myRef={myRef}
       />
+      {!isFetched ? <div className="loader" /> : null}
       <section className="wish-book-wraper">
         <WishBook />
       </section>

--- a/src/component/utils/HeaderMobile.tsx
+++ b/src/component/utils/HeaderMobile.tsx
@@ -35,7 +35,11 @@ const HeaderMobile = () => {
           <Image src={Logo} alt="logo" />
         </Link>
         <nav className="header-mobile__gnb__wrapper">
-          <Link className="header-mobile__search" to={{ pathname: `/search` }}>
+          <Link
+            className="header-mobile__search"
+            to={{ pathname: `/search` }}
+            onClick={() => window.scrollTo(0, 0)}
+          >
             <Image src={SearchBook} alt="search" />
           </Link>
           <button


### PR DESCRIPTION


## 작업내용
### 책 상세 페이지 진입시 스크롤 문제
- 문제
  - 이전 페이지에서 스크롤한 상태일 때, 특히 메인에서 진입시 스크롤 이상함
  - 데스크탑 : 스크롤 중간쯤
   모바일 : 스크롤 최상단
  - breadCrumb 쪽에 scrollIntoView 코드가 들어있지만 제대로 동작하지 않음
- 원인 및 해결
  - 책정보 api가 호출 되기 전 랜더링된 화면에는 scrollIntoView에 연결된 ref가 없음
  - ref.current를 의존성에 추가, ref가 이후 마운트 되더라도 영향을 받도록 
### 추가 스크롤 오류 
- 뒤로가기 클릭시 스크롤이 초기화되는 문제
  - 도서 목록등에서 보고있는 스크롤 위치로 돌아가지 않음
-> 책 상세 진입시 이전 화면의 스크롤 위치를 기억해두고 돌아갈때 다시 설정되도록
- 도서목록으로 진입시 기존스크롤에 영향받는 문제
  - 모바일 화면에서만 문제가 됨
  - 데스크탑은 헤더가 최상단에서만 보임, 기존 스크롤 위치가 문제되지 않음
  -> 모바일 헤더버튼에 최상단으로 스크롤 올리는 로직 추가


|before|after|
|---|---|
|![before](https://github.com/user-attachments/assets/339ab15e-cb44-47c4-8d2e-9a0f6b562257)|![Nov-17-2024 21-00-51](https://github.com/user-attachments/assets/d014ade6-295e-4cd7-9604-5767d1aebbef)|

