### PR TITLE
fix: ios에서 파란색으로 보이는 버그 수정

### DIFF
--- a/src/asset/css/reset.css
+++ b/src/asset/css/reset.css
@@ -136,7 +136,6 @@ a {
   color: #2e363e;
   text-decoration: none;
 }
-
 body {
   font-family: "Noto Sans KR", sans-serif;
   font-stretch: normal;
@@ -147,6 +146,17 @@ body {
   white-space: nowrap;
 }
 
+button {
+  color: #2d2d2d;
+  -webkit-appearance: none;
+  appearance: none;
+}
+
+select {
+  -webkit-appearance: none;
+  appearance: none;
+  color: #2d2d2d;
+}
 /* styleguide CSS */
 
 .color-81 {


### PR DESCRIPTION
# 개요
IOS에서 기본값으로 설정되는 파란색을 검정색으로 설정

# FYI
[IOS 파란색](https://ramincoding.tistory.com/entry/IOS-%EC%9B%B9%EB%B7%B0-%ED%99%94%EB%A9%B4-button-or-a-%ED%83%9C%EA%B7%B8-%ED%85%8D%EC%8A%A4%ED%8A%B8-%EC%83%89%EC%83%81-%ED%8C%8C%EB%9E%80%EC%83%89%EC%9C%BC%EB%A1%9C-%EB%82%98%EC%98%A4%EB%8A%94-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)

<!--
참고: https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
