### PR TITLE
feat: 반납시 대출불가일 안내

### DIFF
--- a/src/api/books/usePatchBooksUpdate.ts
+++ b/src/api/books/usePatchBooksUpdate.ts
@@ -20,7 +20,7 @@ export const usePatchBooksUpdate = ({ bookTitle, closeModal }: Props) => {
 
   const onSuccess = () => {
     addDialogWithTitleAndMessage(
-      `${bookTitle}수정`,
+      `key-book-update-${bookTitle}`,
       "수정되었습니다",
       bookTitle,
       () => {

--- a/src/api/lendings/useGetLendingsSearchId.ts
+++ b/src/api/lendings/useGetLendingsSearchId.ts
@@ -24,7 +24,7 @@ export const useGetLendingsSearchId = ({ setLendingId, openModal }: Props) => {
     } else {
       const title = "책을 다시 한번 확인해주세요.";
       addDialogWithTitleAndMessage(
-        title,
+        `key-error-lending-${title}`,
         title,
         "해당책의 대출기록이 없습니다.",
       );

--- a/src/api/lendings/usePatchLendingsReturn.ts
+++ b/src/api/lendings/usePatchLendingsReturn.ts
@@ -26,7 +26,7 @@ export const usePatchLendingsReturn = ({
 
   const { title, dueDate } = messageData
   const penaltyDays = Math.max(0, messageData.penaltyDays);
-  let message = `${title} 도서는 반납되었습니다.\r\n`
+  let message = `${title} 도서가 반납되었습니다.\r\n`
   const today = new Date().toISOString().split("T")[0];
   const diffDays = Math.ceil((new Date(today).getTime() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24));
 

--- a/src/api/lendings/usePatchLendingsReturn.ts
+++ b/src/api/lendings/usePatchLendingsReturn.ts
@@ -30,14 +30,16 @@ export const usePatchLendingsReturn = ({
   const today = new Date().toISOString().split("T")[0];
   const diffDays = Math.ceil((new Date(today).getTime() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24));
 
+  // 연체 반납, 기존 패널티 존재 X
   if (diffDays > 0 && penaltyDays == 0) {
     message += `${diffDays}일 연체되어 ${diffDays}일 동안 대출이 불가합니다.`
-  }else if (diffDays > 0 && penaltyDays > 0) {
+  // 연체 반납, 기존 패널티 존재 O
+  } else if (diffDays > 0 && penaltyDays > 0) {
     message += `${diffDays}일 연체되어, 기존 ${penaltyDays}일 연체 기간과 합쳐 ${penaltyDays + diffDays}일 동안 대출이 불가합니다.`
-  } else {
-    message += `정상적으로 반납되었습니다.`
+  // 정상 반납, 기존 패널티 존재 O
+  } else if (diffDays <= 0 && penaltyDays > 0) {
+    message += `기존 ${penaltyDays}일 연체 기간이 존재해 ${penaltyDays}일 동안 대출이 불가합니다.`
   }
-
   const { addDialogWithTitleAndMessage } = useNewDialog();
 
   const onSuccess = (response: any) => {

--- a/src/api/lendings/usePatchLendingsReturn.ts
+++ b/src/api/lendings/usePatchLendingsReturn.ts
@@ -4,13 +4,17 @@ import { useNewDialog } from "../../hook/useNewDialog";
 
 type Props = {
   lendingId: number;
-  title: string;
+  messageData: { 
+    title: string; 
+    dueDate: string; 
+    penaltyDays: number; // must be >= 0
+  };
   closeModal: () => void;
 };
 
 export const usePatchLendingsReturn = ({
   lendingId,
-  title: bookTitle,
+  messageData,
   closeModal,
 }: Props) => {
   const [condition, setCondition] = useState("");
@@ -20,6 +24,20 @@ export const usePatchLendingsReturn = ({
     condition,
   });
 
+  const { title, dueDate } = messageData
+  const penaltyDays = Math.max(0, messageData.penaltyDays);
+  let message = `${title} 도서는 반납되었습니다.\r\n`
+  const today = new Date().toISOString().split("T")[0];
+  const diffDays = Math.ceil((new Date(today).getTime() - new Date(dueDate).getTime()) / (1000 * 60 * 60 * 24));
+
+  if (diffDays > 0 && penaltyDays == 0) {
+    message += `${diffDays}일 연체되어 ${diffDays}일 동안 대출이 불가합니다.`
+  }else if (diffDays > 0 && penaltyDays > 0) {
+    message += `${diffDays}일 연체되어, 기존 ${penaltyDays}일 연체 기간과 합쳐 ${penaltyDays + diffDays}일 동안 대출이 불가합니다.`
+  } else {
+    message += `정상적으로 반납되었습니다.`
+  }
+
   const { addDialogWithTitleAndMessage } = useNewDialog();
 
   const onSuccess = (response: any) => {
@@ -27,7 +45,7 @@ export const usePatchLendingsReturn = ({
     const title = response.data?.reservedBook
       ? "예약된 책입니다. 예약자를 위해 따로 보관해주세요."
       : "반납되었습니다.";
-    addDialogWithTitleAndMessage(title, title, bookTitle, () =>
+    addDialogWithTitleAndMessage(title, title, message, () =>
       window.location.reload(),
     );
   };

--- a/src/api/lendings/usePatchLendingsReturn.ts
+++ b/src/api/lendings/usePatchLendingsReturn.ts
@@ -47,7 +47,7 @@ export const usePatchLendingsReturn = ({
     const title = response.data?.reservedBook
       ? "예약된 책입니다. 예약자를 위해 따로 보관해주세요."
       : "반납되었습니다.";
-    addDialogWithTitleAndMessage(title, title, message, () =>
+    addDialogWithTitleAndMessage(`key-return-${title}`, title, message, () =>
       window.location.reload(),
     );
   };

--- a/src/api/lendings/usePostLendings.ts
+++ b/src/api/lendings/usePostLendings.ts
@@ -26,7 +26,7 @@ export const usePostLendings = ({
 
   const onSuccess = () => {
     const message = `${title} - 대출완료`;
-    addDialogWithTitleAndMessage(message, "대출결과", message, closeModal);
+    addDialogWithTitleAndMessage(`key-lending-${message}`, "대출결과", message, closeModal);
   };
 
   const onError = (error: any) => {

--- a/src/api/lendings/usePostLendingsMultiple.ts
+++ b/src/api/lendings/usePostLendingsMultiple.ts
@@ -58,7 +58,7 @@ export const usePostLendingsMultiple = ({
     });
     setSelectedBooks([]);
     setSelectedUser({ ...selectedUser, lendings: lendingSuccess });
-    addDialogWithTitleAndMessage(resultMessage, "대출결과", resultMessage);
+    addDialogWithTitleAndMessage(`key-lending-${resultMessage}`, "대출결과", resultMessage);
     closeModal();
   };
 

--- a/src/api/reservations/usePatchReservationsCancel.ts
+++ b/src/api/reservations/usePatchReservationsCancel.ts
@@ -9,7 +9,7 @@ export const usePatchReservationsCancel = () => {
   const { addConfirmDialog, addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
     addDialogWithTitleAndMessage(
-      "예약취소",
+      "key-reservation-cancel",
       "예약 취소가 완료되었습니다.",
       "",
       () => window.location.reload(),

--- a/src/api/reservations/usePostReservations.ts
+++ b/src/api/reservations/usePostReservations.ts
@@ -19,7 +19,7 @@ export const usePostReservations = ({ bookInfoId }: Props) => {
       rank === 1 && lendabledate
         ? `대출 가능 예상일자는 ${lendabledate}.입니다.`
         : "대출이 가능해지면 Slack 알림을 보내드리겠습니다.";
-    addDialogWithTitleAndMessage(title, title, message);
+    addDialogWithTitleAndMessage("key-reservation-success", title, message);
   };
 
   const postReservation = () => {

--- a/src/api/reviews/usePatchReviewsId.ts
+++ b/src/api/reviews/usePatchReviewsId.ts
@@ -8,7 +8,7 @@ export const usePatchReviewsId = () => {
 
   const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    addDialogWithTitleAndMessage("patched", "처리되었습니다", "", () =>
+    addDialogWithTitleAndMessage("key-review-update", "처리되었습니다", "", () =>
       window.location.reload(),
     );
   };

--- a/src/api/reviews/usePostReview.ts
+++ b/src/api/reviews/usePostReview.ts
@@ -15,7 +15,7 @@ export const usePostReview = ({ bookInfoId, resetTab }: Props) => {
 
   const displaySuccessAndResetTab = () => {
     const title = "성공적으로 등록되었습니다";
-    addDialogWithTitleAndMessage(title, title, "", resetTab);
+    addDialogWithTitleAndMessage("key-review-success", title, "", resetTab);
   };
 
   const request = () =>

--- a/src/api/stock/usePatchStockUpdate.ts
+++ b/src/api/stock/usePatchStockUpdate.ts
@@ -12,7 +12,7 @@ export const usePatchStockUpdate = ({ addList }: Props) => {
 
   const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
-    addDialogWithTitleAndMessage("end", "처리되었습니다", "", addList);
+    addDialogWithTitleAndMessage("key-stock-update", "처리되었습니다", "", addList);
   };
 
   useEffect(() => {

--- a/src/api/tags/useDeleteTagsSuper.ts
+++ b/src/api/tags/useDeleteTagsSuper.ts
@@ -14,7 +14,7 @@ export const useDeleteTagsSuper = ({ removeTag }: Props) => {
   const { addDialogWithTitleAndMessage } = useNewDialog();
   const onSuccess = () => {
     addDialogWithTitleAndMessage(
-      `${tagId}patched`,
+      `key-tag-delete-${tagId}`,
       "처리되었습니다",
       "",
       () => {

--- a/src/api/tags/usePatchTagsSub.ts
+++ b/src/api/tags/usePatchTagsSub.ts
@@ -13,7 +13,7 @@ export const usePatchTagsSub = () => {
 
   const { addDialogWithTitleAndMessage } = useNewDialog();
   const displaySuccess = () => {
-    addDialogWithTitleAndMessage("patched", "처리되었습니다", "", () =>
+    addDialogWithTitleAndMessage("key-tag-patched", "처리되었습니다", "", () =>
       window.location.reload(),
     );
   };

--- a/src/api/tags/usePostTagsSuper.ts
+++ b/src/api/tags/usePostTagsSuper.ts
@@ -22,7 +22,7 @@ export const usePostTagsSuper = ({ bookInfoId, addTag }: Props) => {
     addTag(newTag);
 
     addDialogWithTitleAndMessage(
-      `${newTag.content} 추가`,
+      `key-tag-add-${newTag.content}`,
       "태그가 추가되었습니다.",
       newTag.content,
     );

--- a/src/api/users/usePatchUsersMyupdate.ts
+++ b/src/api/users/usePatchUsersMyupdate.ts
@@ -17,7 +17,7 @@ export const usePatchUsersMyupdate = ({ modeString }: Props) => {
   const { addDialogWithTitleAndMessage, addErrorDialog } = useNewDialog();
   const onSuccess = () => {
     const title = `${modeString} 변경 성공`;
-    addDialogWithTitleAndMessage(title, title, "", () => navigate("/auth"));
+    addDialogWithTitleAndMessage(`key-user-${title}`, title, "", () => navigate("/auth"));
   };
 
   const onError = (error: any) => {

--- a/src/api/users/usePostUsersCreate.ts
+++ b/src/api/users/usePostUsersCreate.ts
@@ -31,7 +31,7 @@ export const usePostUsersCreate = () => {
 
   const displaySuccess = () => {
     addDialogWithTitleAndMessage(
-      "회원가입 완료",
+      "key-user-signup",
       "회원가입 완료",
       "환영합니다. 로그인 후 집현전 서비스를 이용하세요.",
       () => navigate("/login"),

--- a/src/component/mypage/EditEmailOrPassword.tsx
+++ b/src/component/mypage/EditEmailOrPassword.tsx
@@ -46,7 +46,7 @@ function EditEmailOrPassword() {
       title = registerRule[modeString].invalidMessage;
     else if (!revision.text) title = `${modeStringKorean}를 다시 확인해주세요`;
 
-    addDialogWithTitleAndMessage(title, title, "");
+    addDialogWithTitleAndMessage(`key-error-${title}`, title, "");
     setPatchData({ [modeString]: revision.text });
   };
 

--- a/src/component/mypage/Mypage.tsx
+++ b/src/component/mypage/Mypage.tsx
@@ -48,7 +48,7 @@ const Mypage = () => {
     if (error) {
       const errorCode = parseInt(error, 10);
       const [title, message] = getErrorMessage(errorCode).split("\r\n");
-      addDialogWithTitleAndMessage(title, title, message, () => {
+      addDialogWithTitleAndMessage(`key-error-${title}`, title, message, () => {
         urlQuery.delete("errorCode");
         setUrlQuery(urlQuery);
       });

--- a/src/component/rent/RentModalBook.tsx
+++ b/src/component/rent/RentModalBook.tsx
@@ -34,7 +34,7 @@ const RentModalBook = ({
     );
     if (isAlreadySelected) {
       addDialogWithTitleAndMessage(
-        "alreadySelected",
+        "key-error-alreadySelected",
         "이미 선택된 도서입니다.",
         "다시 한번 확인해주세요",
       );

--- a/src/component/return/ReturnModalContents.tsx
+++ b/src/component/return/ReturnModalContents.tsx
@@ -19,7 +19,11 @@ const ReturnModalContents = ({ lendingId, closeModal }: Props) => {
 
   const { condition, setCondition, requestReturn } = usePatchLendingsReturn({
     lendingId,
-    title: lendingData?.title || "",
+    messageData: {
+      title: lendingData?.title || "",
+      dueDate: lendingData?.dueDate || "",
+      penaltyDays: lendingData?.penaltyDays || 0,
+    },
     closeModal,
   });
 

--- a/src/component/utils/BarcodeReader.tsx
+++ b/src/component/utils/BarcodeReader.tsx
@@ -17,7 +17,7 @@ const BarcodeReader = ({ toDoAfterRead, wrapperClassName = "" }: Props) => {
 
   const { addDialogWithTitleAndMessage } = useNewDialog();
   const alertError = (message: string) => {
-    addDialogWithTitleAndMessage("barcodeReader", "바코드 리더 에러", message);
+    addDialogWithTitleAndMessage("key-error-barcodeReader", "바코드 리더 에러", message);
   };
 
   const loadVideoInputDeviceList = useCallback(async () => {

--- a/src/component/utils/HandleReview.tsx
+++ b/src/component/utils/HandleReview.tsx
@@ -54,7 +54,7 @@ const HandleReview = ({ type, review, deleteReview }: Props) => {
       request();
     } else {
       addDialogWithTitleAndMessage(
-        "error",
+        "key-error-review-length",
         "10자 이상 420자 이하로 입력해주세요.",
         "",
       );

--- a/src/component/utils/HiddenModal.jsx
+++ b/src/component/utils/HiddenModal.jsx
@@ -8,7 +8,7 @@ const HiddenModal = () => {
     const error = JSON.parse(window.localStorage.getItem("error"));
     if (error) {
       addDialogWithTitleAndMessage(
-        error?.title,
+        `key-error-${error?.title}`,
         error?.title,
         error?.message,
         () => window.localStorage.removeItem("error"),

--- a/src/hook/useNewDialog.ts
+++ b/src/hook/useNewDialog.ts
@@ -37,7 +37,7 @@ export const useNewDialog = () => {
   };
 
   /** 간단하게 다이얼로그 호출
-   * @param key 다이얼로그를 구분할 키, 같은 키로 이미 열린 다이얼로그가 있으면 추가되지 않음
+   * @param key 다이얼로그를 구분할 키, 'key-{domain}-{title}' 형식으로 작성 (예: 'key-error-book-update, key-return-반납되었습니다.')
    * @param title  제목
    * @param message 내용
    * @param afterClose 다이얼로그가 닫힌 후 실행할 함수
@@ -87,7 +87,7 @@ export const useNewDialog = () => {
     const errorCode = error?.response?.data?.errorCode;
     const [title, message] = getErrorMessage(errorCode).split("\r\n");
     addDialogWithTitleAndMessage(
-      title, // 같은 오류메세지를 여러번 띄우는 것을 방지하기 위해 title을 key로 사용
+      `key-error-${errorCode}`,
       title,
       errorCode ? message : message + "\n" + error.message,
       () => {

--- a/src/hook/usePermission.ts
+++ b/src/hook/usePermission.ts
@@ -20,7 +20,7 @@ export const usePermission = () => {
       return;
     }
     addDialogWithTitleAndMessage(
-      "not authenticated",
+      "key-error-not-authenticated",
       forbiddenMessage || "42 인증 유저만 접근할 수 있는 기능입니다.",
       "42 인증은 마이페이지에서 진행하실 수 있습니다.",
     );


### PR DESCRIPTION
# 📚 도서 반납 시 패널티 메시지 개선

## 🔍 개요
- fixes #652 - 도서 반납 시 패널티 관련 메시지 개선

## 🖼️ 변경된 화면

### 1. 연체 반납 & 기존 패널티 없음
![연체 반납 & 기존 패널티 없음](https://github.com/user-attachments/assets/090136ff-334a-412d-92ab-826ae99ec778)
- 연체 일수만큼 대출 제한 메시지 표시

### 2. 연체 반납 & 기존 패널티 존재
![연체 반납 & 기존 패널티 존재](https://github.com/user-attachments/assets/7becacd0-85b4-4f38-b0db-12fb8b76a597)
- 기존 패널티와 신규 연체 일수의 합계 표시

### 3. 정상 반납 & 기존 패널티 존재
![정상 반납 & 기존 패널티 존재](https://github.com/user-attachments/assets/439d623f-a0a1-4e6d-8a15-c15406363854)
- 기존 패널티 일수 안내

### 4. 정상 반납 & 기존 패널티 없음
![정상 반납 & 기존 패널티 없음](https://github.com/user-attachments/assets/71c227b7-dce1-4af8-a7ae-0b0759d4d8b1)
- 일반 반납 완료 메시지

## 💡 주요 변경사항
- 패널티 메시지 로직 개선
- 음수 패널티 방지 로직 추가
- 메시지 포맷 일관성 개선